### PR TITLE
Add cmake install target and update dependencies in readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8)
 project(inspectrum CXX)
 enable_testing()
 
@@ -6,6 +6,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
+# This only works in cmake >3.1
+#set_property(TARGET inspectrum PROPERTY CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 list(APPEND inspectrum_sources 
@@ -18,12 +20,14 @@ list(APPEND inspectrum_sources
 )
 
 INCLUDE(FindPkgConfig)
-
-find_package(Qt5Widgets)
+find_package(Qt5Widgets REQUIRED)
 pkg_check_modules(FFTW REQUIRED fftw3f)
 include_directories(${QT_INCLUDES} ${FFTW_INCLUDEDIR})
 
 add_executable(inspectrum ${inspectrum_sources})
 qt5_use_modules(inspectrum Widgets)
+
 target_link_libraries(inspectrum ${QT_LIBRARIES} ${FFTW_LIBRARIES})
-set_property(TARGET inspectrum PROPERTY CXX_STANDARD 11)
+set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX")
+
+install(TARGETS inspectrum RUNTIME DESTINATION ${INSTALL_DEFAULT_BINDIR})

--- a/README.md
+++ b/README.md
@@ -7,24 +7,27 @@ inspectrum is a tool for analysing captured signals, primarily from software-def
 ### Prerequisites
 
  * qt5
- * cmake
  * fftw 3.x
+ * cmake
+ * pkg-config
 
 ### Building on Debian-based distros
 
-    sudo apt-get install qt5-default cmake libfftw3-dev
+    sudo apt-get install qt5-default libfftw3-dev cmake pkg-config
     mkdir build
     cd build
     cmake ..
     make
+    sudo make install
 
 
 ## Building on OSX
 
-    brew install qt5 cmake fftw pkg-config
+    brew install qt5 fftw cmake pkg-config
     mkdir build
     cd build
     CMAKE_PREFIX_PATH=$(brew --prefix qt5)/lib/cmake cmake ..
+    make install
 
 
 ### Run


### PR DESCRIPTION
This fixes #24 and adds an install target so that inspectrum can be installed in /usr/local/bin (or your preferred path).