### PR TITLE
Exec command

### DIFF
--- a/cut_sample.py
+++ b/cut_sample.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import os
+import sys
+import getopt
+import numpy
+import scipy.signal
+import subprocess
+
+if __name__ == "__main__":
+    options, remainder = getopt.getopt(sys.argv[1:], 'v', [
+                                                            'verbose',
+                                                            ])
+    verbose = False
+
+    for opt, arg in options:
+        if opt in ('-v', '--verbose'):
+            verbose = True
+
+    if len(remainder)!=7:
+        print >> sys.stderr, "ERR: need 7 arguments"
+
+    filename=    remainder[0]
+    sample_rate= long(remainder[1])
+    start_sample=long(remainder[2])
+    end_sample=  long(remainder[3])
+    min_freq=    long(remainder[4])
+    max_freq=    long(remainder[5])
+    center_freq= long(remainder[6])
+
+    bps=8 # Byte per sample
+    outfile="/tmp/sample.bin"
+
+    freq_offset=(max_freq+min_freq)/2 - center_freq
+    freq_window=(max_freq-min_freq)
+
+    if verbose:
+        print "Cutting",start_sample,"-",end_sample,"from",filename,"..."
+        print "Center is",center_freq,"sample_rate=",sample_rate
+    
+    f = open(filename, "rb")
+    f.seek(start_sample*bps, os.SEEK_SET)
+    signal = numpy.fromfile(f, dtype=numpy.complex64, count=end_sample-start_sample)  # read the data into numpy
+
+    # shift marked signal to center freq
+    if verbose:
+        print "Shifting signal by",freq_offset,"Hz"
+    shift = numpy.exp(complex(0,-1)*numpy.arange(len(signal))*2*numpy.pi*freq_offset/float(sample_rate))
+    signal = signal*shift
+
+    # Filter unwanted part
+    if verbose:
+        print "Filtering ",freq_window,"Hz"
+    low_pass = scipy.signal.firwin(401, freq_window/2, nyq=sample_rate)
+    signal = numpy.convolve(signal, low_pass, mode='same')
+
+    # Decimate a bit (if possible)
+    decimate = int(sample_rate/freq_window)
+    if decimate > 4:
+        decimate=4
+    if verbose:
+        print "Decimating by ",decimate
+    signal=signal[::decimate]
+
+    # Write file
+    if type(signal)!=numpy.complex64:
+        signal=numpy.asarray(signal,dtype=numpy.complex64)
+    signal.tofile(outfile)
+
+    # Run inspectrum to display result
+    command=["inspectrum","-c",str(center_freq+freq_offset),"-r",str(sample_rate/decimate),outfile]
+    if verbose:
+        print "Running command:",command
+    subprocess.call(command)

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,11 @@ int main(int argc, char *argv[])
 	    QCoreApplication::translate("main", "Hz"));
     parser.addOption(centerOption);
 
+    QCommandLineOption execOption(QStringList() << "x" << "exec",
+	    QCoreApplication::translate("main", "Helper to execute."),
+	    QCoreApplication::translate("main", "path to binary"));
+    parser.addOption(execOption);
+
     // Process the actual command line
     parser.process(a);
 
@@ -46,6 +51,9 @@ int main(int argc, char *argv[])
 	    return 1;
 	}
 	mainWin.changeCenterFreq(rate);
+    }
+    if (parser.isSet(execOption)){
+	mainWin.setExecCommand(parser.value(execOption));
     }
 
     const QStringList args = parser.positionalArguments();

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,11 @@ int main(int argc, char *argv[])
 	    QCoreApplication::translate("main", "Hz"));
     parser.addOption(rateOption);
 
+    QCommandLineOption centerOption(QStringList() << "c" << "center",
+	    QCoreApplication::translate("main", "Set center frequency."),
+	    QCoreApplication::translate("main", "Hz"));
+    parser.addOption(centerOption);
+
     // Process the actual command line
     parser.process(a);
 
@@ -32,6 +37,15 @@ int main(int argc, char *argv[])
 	    return 1;
 	}
 	mainWin.changeSampleRate(rate);
+    }
+    if (parser.isSet(centerOption)){
+	bool ok;
+	int rate = parser.value(centerOption).toInt(&ok);
+	if(!ok){
+	    fputs("ERROR: could not parse center frequency\n", stderr);
+	    return 1;
+	}
+	mainWin.changeCenterFreq(rate);
     }
 
     const QStringList args = parser.positionalArguments();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,4 +1,5 @@
 #include <QtWidgets>
+#include <QRubberBand>
 
 #include "mainwindow.h"
 
@@ -22,6 +23,9 @@ MainWindow::MainWindow()
     connect(dock->powerMinSlider, SIGNAL(valueChanged(int)), &spectrogram, SLOT(setPowerMin(int)));
 }
 
+QRubberBand *rubberBand=NULL;
+QPoint mystart;
+
 bool MainWindow::eventFilter(QObject * /*obj*/, QEvent *event)
 {
     if (event->type() == QEvent::Wheel) {
@@ -40,7 +44,51 @@ bool MainWindow::eventFilter(QObject * /*obj*/, QEvent *event)
             }
             return true;
         }
-    }
+    }else if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent *mouseEvent = (QMouseEvent*)event;
+		if (mouseEvent->buttons() == Qt::LeftButton){
+			mystart = (mouseEvent->pos());
+			if(!rubberBand)
+				rubberBand = new QRubberBand(QRubberBand::Rectangle, scrollArea.viewport());
+			rubberBand->setGeometry(QRect(mystart, mystart));
+			rubberBand->show();
+			return true;
+		}
+    }else if (event->type() == QEvent::MouseMove) {
+        QMouseEvent *mouseEvent = (QMouseEvent*)event;
+		if (mouseEvent->buttons() == Qt::LeftButton){
+			rubberBand->setGeometry(QRect(mystart, mouseEvent->pos()).normalized()); //Area Bounding
+			return true;
+		}
+    }else if (event->type() == QEvent::MouseButtonRelease) {
+        QMouseEvent *mouseEvent = (QMouseEvent*)event;
+		QRect rb= rubberBand->geometry();
+
+		int topSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top());
+		int bottomSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom());
+
+		int leftFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
+		int rightFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
+
+		QStringList command;
+		command << "cut_sample" << spectrogram.getFileName() << QString::number(spectrogram.getSampleRate())
+		<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top()))
+		<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom()))
+
+		<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
+		<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
+		<< QString::number(spectrogram.getCenterFreq())
+		;
+
+		if(system(command.join(" ").toLatin1().data())){
+			QMessageBox msgBox;
+			msgBox.setText("cut_sample call failed.");
+			msgBox.exec();
+		};
+		rubberBand->hide();
+		rubberBand->clearMask();
+		return true;
+	};
     return false;
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -44,58 +44,59 @@ bool MainWindow::eventFilter(QObject * /*obj*/, QEvent *event)
             }
             return true;
         }
-    }else if (event->type() == QEvent::MouseButtonPress) {
-        QMouseEvent *mouseEvent = (QMouseEvent*)event;
-		if (mouseEvent->buttons() == Qt::LeftButton){
-			mystart = (mouseEvent->pos());
-			if(!rubberBand)
-				rubberBand = new QRubberBand(QRubberBand::Rectangle, scrollArea.viewport());
-			rubberBand->setGeometry(QRect(mystart, mystart));
-			rubberBand->show();
-			return true;
-		}
-    }else if (event->type() == QEvent::MouseMove) {
-        QMouseEvent *mouseEvent = (QMouseEvent*)event;
-		if (mouseEvent->buttons() == Qt::LeftButton){
-			rubberBand->setGeometry(QRect(mystart, mouseEvent->pos()).normalized()); //Area Bounding
-			return true;
-		}
-    }else if (event->type() == QEvent::MouseButtonRelease) {
-        QMouseEvent *mouseEvent = (QMouseEvent*)event;
-		QRect rb= rubberBand->geometry();
+    }else if (!execCommand.isEmpty())
+		if (event->type() == QEvent::MouseButtonPress) {
+			QMouseEvent *mouseEvent = (QMouseEvent*)event;
+			if (mouseEvent->buttons() == Qt::LeftButton){
+				mystart = (mouseEvent->pos());
+				if(!rubberBand)
+					rubberBand = new QRubberBand(QRubberBand::Rectangle, scrollArea.viewport());
+				rubberBand->setGeometry(QRect(mystart, mystart));
+				rubberBand->show();
+				return true;
+			}
+		}else if (event->type() == QEvent::MouseMove) {
+			QMouseEvent *mouseEvent = (QMouseEvent*)event;
+			if (mouseEvent->buttons() == Qt::LeftButton){
+				rubberBand->setGeometry(QRect(mystart, mouseEvent->pos()).normalized()); //Area Bounding
+				return true;
+			}
+		}else if (event->type() == QEvent::MouseButtonRelease) {
+			QMouseEvent *mouseEvent = (QMouseEvent*)event;
+			QRect rb= rubberBand->geometry();
 
-		if(rb.top()==rb.bottom() or rb.left()==rb.right() or
-			( rb.bottom()-rb.top()<10 and rb.right()-rb.left()<10) ){
+			if(rb.top()==rb.bottom() or rb.left()==rb.right() or
+					( rb.bottom()-rb.top()<10 and rb.right()-rb.left()<10) ){
+				rubberBand->hide();
+				rubberBand->clearMask();
+				return false;
+			}
+
+			int topSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top());
+			int bottomSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom());
+
+			int leftFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
+			int rightFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
+
+			QStringList command;
+			command << execCommand << spectrogram.getFileName() << QString::number(spectrogram.getSampleRate())
+				<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top()))
+				<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom()))
+
+				<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
+				<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
+				<< QString::number(spectrogram.getCenterFreq())
+				;
+
+			if(system(command.join(" ").toLatin1().data())){
+				QMessageBox msgBox;
+				msgBox.setText("cut_sample call failed.");
+				msgBox.exec();
+			};
 			rubberBand->hide();
 			rubberBand->clearMask();
-			return false;
-		}
-
-		int topSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top());
-		int bottomSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom());
-
-		int leftFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
-		int rightFreq=(int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize();
-
-		QStringList command;
-		command << "cut_sample" << spectrogram.getFileName() << QString::number(spectrogram.getSampleRate())
-		<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top()))
-		<< QString::number(spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom()))
-
-		<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.left())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
-		<< QString::number((long int)(scrollArea.horizontalScrollBar()->value() + rb.right())*spectrogram.getSampleRate()/spectrogram.getFFTSize() +spectrogram.getCenterFreq() -spectrogram.getSampleRate()/2)
-		<< QString::number(spectrogram.getCenterFreq())
-		;
-
-		if(system(command.join(" ").toLatin1().data())){
-			QMessageBox msgBox;
-			msgBox.setText("cut_sample call failed.");
-			msgBox.exec();
+			return true;
 		};
-		rubberBand->hide();
-		rubberBand->clearMask();
-		return true;
-	};
     return false;
 }
 
@@ -126,6 +127,11 @@ void MainWindow::setFFTSize(int size)
     off_t sample = getCenterSample();
     spectrogram.setFFTSize(size);
     scrollArea.verticalScrollBar()->setValue(getScrollPos(sample));
+}
+
+void MainWindow::setExecCommand(QString command)
+{
+    execCommand=command;
 }
 
 void MainWindow::setZoomLevel(int zoom)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -64,6 +64,13 @@ bool MainWindow::eventFilter(QObject * /*obj*/, QEvent *event)
         QMouseEvent *mouseEvent = (QMouseEvent*)event;
 		QRect rb= rubberBand->geometry();
 
+		if(rb.top()==rb.bottom() or rb.left()==rb.right() or
+			( rb.bottom()-rb.top()<10 and rb.right()-rb.left()<10) ){
+			rubberBand->hide();
+			rubberBand->clearMask();
+			return false;
+		}
+
 		int topSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.top());
 		int bottomSample=spectrogram.lineToSample(scrollArea.verticalScrollBar()->value()+ rb.bottom());
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -15,6 +15,7 @@ MainWindow::MainWindow()
 
     connect(dock, SIGNAL(openFile(QString)), this, SLOT(openFile(QString)));
     connect(dock->sampleRate, SIGNAL(textChanged(QString)), this, SLOT(setSampleRate(QString)));
+    connect(dock->centerFreq, SIGNAL(textChanged(QString)), this, SLOT(setCenterFreq(QString)));
     connect(dock, SIGNAL(fftSizeChanged(int)), this, SLOT(setFFTSize(int)));
     connect(dock->zoomLevelSlider, SIGNAL(valueChanged(int)), this, SLOT(setZoomLevel(int)));
     connect(dock->powerMaxSlider, SIGNAL(valueChanged(int)), &spectrogram, SLOT(setPowerMax(int)));
@@ -52,6 +53,17 @@ void MainWindow::changeSampleRate(int rate)
 {
     spectrogram.setSampleRate(rate);
     dock->sampleRate->setText(QString::number(rate));
+}
+
+void MainWindow::setCenterFreq(QString rate)
+{
+    spectrogram.setCenterFreq(rate.toInt());
+}
+
+void MainWindow::changeCenterFreq(int rate)
+{
+    spectrogram.setCenterFreq(rate);
+    dock->centerFreq->setText(QString::number(rate));
 }
 
 void MainWindow::setFFTSize(int size)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -20,6 +20,7 @@ public slots:
 	void setCenterFreq(QString rate);
 	void setFFTSize(int size);
 	void setZoomLevel(int zoom);
+	void setExecCommand(QString command);
 
 protected:
 	bool eventFilter(QObject *obj, QEvent *event);
@@ -28,6 +29,7 @@ private:
     QScrollArea scrollArea;
     Spectrogram spectrogram;
     SpectrogramControls *dock;
+    QString execCommand;
 
 	off_t getCenterSample();
 	int getScrollPos(off_t sample);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,10 +12,12 @@ class MainWindow : public QMainWindow
 public:
     MainWindow();
     void changeSampleRate(int rate);
+    void changeCenterFreq(int rate);
 
 public slots:
     void openFile(QString fileName);
 	void setSampleRate(QString rate);
+	void setCenterFreq(QString rate);
 	void setFFTSize(int size);
 	void setZoomLevel(int zoom);
 

--- a/spectrogram.cpp
+++ b/spectrogram.cpp
@@ -16,6 +16,7 @@ Spectrogram::Spectrogram()
 	zoomLevel = 0;
 	powerMax = 0.0f;
 	powerMin = -50.0f;
+	curName = "<none>";
 
 	for (int i = 0; i < 256; i++) {
 		float p = (float)i / 256;
@@ -36,6 +37,7 @@ QSize Spectrogram::sizeHint() const {
 void Spectrogram::openFile(QString fileName)
 {
 	if (fileName != nullptr) {
+		curName=fileName;
 		try {
 			InputSource *newFile = new InputSource(fileName.toUtf8().constData());
 			delete inputSource;
@@ -47,6 +49,11 @@ void Spectrogram::openFile(QString fileName)
 			// TODO: display error
 		}
 	}
+}
+
+QString Spectrogram::getFileName()
+{
+	return curName;
 }
 
 template <class T> const T& clamp (const T& value, const T& min, const T& max) {

--- a/spectrogram.cpp
+++ b/spectrogram.cpp
@@ -186,6 +186,16 @@ int Spectrogram::getSampleRate()
 	return sampleRate;
 }
 
+void Spectrogram::setCenterFreq(int hz)
+{
+	centerFreq = hz;
+}
+
+int Spectrogram::getCenterFreq()
+{
+	return centerFreq;
+}
+
 void Spectrogram::setFFTSize(int size)
 {
 	fftSize = size;

--- a/spectrogram.cpp
+++ b/spectrogram.cpp
@@ -181,6 +181,11 @@ void Spectrogram::setSampleRate(int rate)
 	update();
 }
 
+int Spectrogram::getSampleRate()
+{
+	return sampleRate;
+}
+
 void Spectrogram::setFFTSize(int size)
 {
 	fftSize = size;
@@ -193,6 +198,11 @@ void Spectrogram::setFFTSize(int size)
 	}
 
 	resize(fftSize, getHeight());
+}
+
+int Spectrogram::getFFTSize()
+{
+	return fftSize;
 }
 
 void Spectrogram::setPowerMax(int power)

--- a/spectrogram.h
+++ b/spectrogram.h
@@ -20,6 +20,8 @@ public:
 	QSize sizeHint() const;
 	int getHeight();
 	int getStride();
+	int getSampleRate();
+	int getFFTSize();
 	QString getFileName();
 
 public slots:
@@ -29,6 +31,7 @@ public slots:
 	void setPowerMax(int power);
 	void setPowerMin(int power);
 	void setZoomLevel(int zoom);
+	off_t lineToSample(int line);
 
 protected:
 	void paintEvent(QPaintEvent *event);
@@ -57,7 +60,6 @@ private:
 	float* getFFTTile(off_t tile);
 	void getLine(float *dest, off_t sample);
 	void paintTimeAxis(QPainter *painter, QRect rect);
-	off_t lineToSample(int line);
 	int sampleToLine(off_t sample);
 	QString sampleToTime(off_t sample);
 	int linesPerTile();

--- a/spectrogram.h
+++ b/spectrogram.h
@@ -20,6 +20,7 @@ public:
 	QSize sizeHint() const;
 	int getHeight();
 	int getStride();
+	QString getFileName();
 
 public slots:
 	void openFile(QString fileName);
@@ -50,6 +51,7 @@ private:
 	int zoomLevel;
 	float powerMax;
 	float powerMin;
+	QString curName;
 
 	QPixmap* getPixmapTile(off_t tile);
 	float* getFFTTile(off_t tile);

--- a/spectrogram.h
+++ b/spectrogram.h
@@ -21,12 +21,14 @@ public:
 	int getHeight();
 	int getStride();
 	int getSampleRate();
+	int getCenterFreq();
 	int getFFTSize();
 	QString getFileName();
 
 public slots:
 	void openFile(QString fileName);
 	void setSampleRate(int rate);
+	void setCenterFreq(int hz);
 	void setFFTSize(int size);
 	void setPowerMax(int power);
 	void setPowerMin(int power);
@@ -50,6 +52,7 @@ private:
 	uint colormap[256];
 
 	int sampleRate;
+	int centerFreq;
 	int fftSize;
 	int zoomLevel;
 	float powerMax;

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -17,6 +17,10 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 	sampleRate->setValidator(new QIntValidator(this));
 	layout->addRow(new QLabel(tr("Sample rate:")), sampleRate);
 
+	centerFreq = new QLineEdit("0");
+	centerFreq->setValidator(new QIntValidator(this));
+	layout->addRow(new QLabel(tr("Center freq:")), centerFreq);
+
 	fftSizeSlider = new QSlider(Qt::Horizontal, widget);
 	fftSizeSlider->setRange(7, 13);
 	fftSizeSlider->setValue(10);

--- a/spectrogramcontrols.h
+++ b/spectrogramcontrols.h
@@ -26,6 +26,7 @@ private:
 public:
 	QPushButton *fileOpenButton;
 	QLineEdit *sampleRate;
+	QLineEdit *centerFreq;
 	QSlider *fftSizeSlider;
 	QSlider *zoomLevelSlider;
 	QSlider *powerMaxSlider;


### PR DESCRIPTION
This adds a commandline option that allows you to enable execCommand mode.
In this mode you can select a rectangle in the spectrogram which calls an external helper with the four corners as parameters, so you can easily post-process small snippets of a larger file.

This also adds an option to set the center frequency of the file. I had also planned to display a frequency axis, but my QT foo is currently too weak for this.