### PR TITLE
feat(annotation): Parse a CSV file to show annotations

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,11 @@ int main(int argc, char *argv[])
 	    QCoreApplication::translate("main", "Hz"));
     parser.addOption(rateOption);
 
+    QCommandLineOption annotationOption(QStringList() << "a" << "annotations",
+	    QCoreApplication::translate("main", "CSV file with annotations: time, frequency, text"),
+	    QCoreApplication::translate("main", "filename"));
+    parser.addOption(annotationOption);
+
     // Process the actual command line
     parser.process(a);
 
@@ -32,6 +37,10 @@ int main(int argc, char *argv[])
 	    return 1;
 	}
 	mainWin.changeSampleRate(rate);
+    }
+
+    if (parser.isSet(annotationOption)){
+	mainWin.openAnnotationFile(parser.value(annotationOption));
     }
 
     const QStringList args = parser.positionalArguments();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -86,3 +86,9 @@ void MainWindow::openFile(QString fileName)
     this->setWindowTitle(title.arg(QApplication::applicationName(),fileName.section('/',-1,-1)));
     spectrogram.openFile(fileName);
 }
+
+void MainWindow::openAnnotationFile(QString fileName)
+{
+    spectrogram.openAnnotationFile(fileName);
+}
+

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,6 +12,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow();
     void changeSampleRate(int rate);
+    void openAnnotationFile(QString fileName);
 
 public slots:
     void openFile(QString fileName);

--- a/spectrogram.cpp
+++ b/spectrogram.cpp
@@ -59,16 +59,22 @@ void Spectrogram::openAnnotationFile(QString fileName)
 	QTextStream in(&data);
 	QString line;
 
-	while(!in.atEnd()) {
+	while (!in.atEnd()) {
 		line = in.readLine();
 		struct annotation a;
 
 		QStringList splitline = line.split(',');
-		a.timestamp = splitline[0].toDouble();
-		a.frequency = splitline[1].toDouble();
-		a.text = new QString(splitline[2]);
 
-		annotationList.append(a);
+		if (splitline.size() > 2) {
+			bool ok1, ok2;
+			a.timestamp = splitline[0].toDouble(&ok1);
+			a.frequency = splitline[1].toDouble(&ok2);
+			a.text = new QString(splitline[2]);
+
+			if (ok1 && ok2) {
+				annotationList.append(a);
+			}
+		}
 	}
 }
 

--- a/spectrogram.cpp
+++ b/spectrogram.cpp
@@ -49,6 +49,29 @@ void Spectrogram::openFile(QString fileName)
 	}
 }
 
+void Spectrogram::openAnnotationFile(QString fileName)
+{
+	QFile data(fileName);
+	if (!data.open(QFile::ReadOnly)) {
+		return;
+	}
+
+	QTextStream in(&data);
+	QString line;
+
+	while(!in.atEnd()) {
+		line = in.readLine();
+		struct annotation a;
+
+		QStringList splitline = line.split(',');
+		a.timestamp = splitline[0].toDouble();
+		a.frequency = splitline[1].toDouble();
+		a.text = new QString(splitline[2]);
+
+		annotationList.append(a);
+	}
+}
+
 template <class T> const T& clamp (const T& value, const T& min, const T& max) {
     return std::min(max, std::max(min, value));
 }
@@ -79,6 +102,7 @@ void Spectrogram::paintEvent(QPaintEvent *event)
 		}
 
 		paintTimeAxis(&painter, rect);
+		paintAnnotations(&painter, rect);
 	}
 
 	qDebug() << "Paint: " << timer.elapsed() << "ms";
@@ -165,6 +189,31 @@ void Spectrogram::paintTimeAxis(QPainter *painter, QRect rect)
 		painter->drawLine(0, line, 10, line);
 		painter->drawText(12, line + textOffset, sampleToTime(lineToSample(line)));
 	}
+	painter->restore();
+}
+
+void Spectrogram::paintAnnotations(QPainter *painter, QRect rect)
+{
+	int firstSample = lineToSample(rect.y());
+	int lastSample = lineToSample(rect.y() + rect.height());
+
+	float startTime = (float)firstSample / sampleRate;
+	float stopTime = (float)lastSample / sampleRate;
+
+	painter->save();
+	QPen pen(Qt::white, 1, Qt::SolidLine);
+	painter->setPen(pen);
+	QFontMetrics fm(painter->font());
+
+	for (int i = 0; i < annotationList.size(); ++i) {
+		struct annotation a = annotationList.at(i);
+		if (startTime <= a.timestamp && stopTime >= a.timestamp) {
+			// TODO: Use real centerFreq once available
+			int centerFreq = 0;
+			painter->drawText(((a.frequency - centerFreq) /sampleRate + 0.5) * fftSize, sampleToLine(sampleRate * a.timestamp), *a.text);
+		}
+	}
+
 	painter->restore();
 }
 

--- a/spectrogram.h
+++ b/spectrogram.h
@@ -9,6 +9,12 @@
 
 static const double Tau = M_PI * 2.0;
 
+struct annotation {
+	double timestamp;
+	double frequency;
+	QString *text;
+};
+
 class TileCacheKey;
 
 class Spectrogram : public QWidget {
@@ -20,6 +26,7 @@ public:
 	QSize sizeHint() const;
 	int getHeight();
 	int getStride();
+	void openAnnotationFile(QString fileName);
 
 public slots:
 	void openFile(QString fileName);
@@ -44,6 +51,7 @@ private:
 	QCache<TileCacheKey, QPixmap> pixmapCache;
 	QCache<TileCacheKey, float> fftCache;
 	uint colormap[256];
+	QList<struct annotation> annotationList;
 
 	int sampleRate;
 	int fftSize;
@@ -56,6 +64,7 @@ private:
 	void getLine(float *dest, off_t sample);
 	void paintTimeAxis(QPainter *painter, QRect rect);
 	off_t lineToSample(int line);
+	void paintAnnotations(QPainter *painter, QRect rect);
 	int sampleToLine(off_t sample);
 	QString sampleToTime(off_t sample);
 	int linesPerTile();


### PR DESCRIPTION
This PR implements the option to show annotations inside the spectrum.

It reads data from a CSV file in the following format:
```
<timestamp>,<frequency>,<annotation>
```

Example:
```
0.25,1626000000,Packet 1
10.2,1625500000,Packet 2
```

Here is a screenshot with this being used to annotate a file with some captured and decoded Iridium packets:

![screenshot from 2015-10-02 22 12 01](https://cloud.githubusercontent.com/assets/452051/10257153/f9ed9942-6955-11e5-9372-6fa7a0b8f376.png)

(The screenshot also makes use of the center frequency option introduced by #33)

