### PR TITLE
fixed crash when QFileDialog is closed without selecting a file

### DIFF
--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -127,7 +127,8 @@ void SpectrogramControls::fileOpenButtonClicked()
     QString fileName = QFileDialog::getOpenFileName(
                            this, tr("Open File"), "", tr("Sample file (*.cfile *.bin);;All files (*)")
                        );
-    emit openFile(fileName);
+    if (!fileName.isEmpty())
+        emit openFile(fileName);
 }
 
 void SpectrogramControls::timeSelectionChanged(float time)


### PR DESCRIPTION
This will fix a crash. The crash occurs when the QFileDialog is closed without selecting a File.