### PR TITLE
Support for multiple file formats

### DIFF
--- a/inputsource.cpp
+++ b/inputsource.cpp
@@ -29,6 +29,8 @@
 #include <stdexcept>
 #include <algorithm>
 
+#include <QFileInfo>
+
 class ComplexF32SampleAdapter : public SampleAdapter {
 public:
     size_t sampleSize() override {
@@ -100,6 +102,21 @@ void InputSource::cleanup()
 
 void InputSource::openFile(const char *filename)
 {
+    QFileInfo fileInfo(filename);
+    const auto suffix = fileInfo.suffix();
+    if( (suffix == "cfile") || (suffix == "cf32") ) {
+        sampleAdapter = std::unique_ptr<SampleAdapter>(new ComplexF32SampleAdapter());
+    }
+    else if( suffix == "cs8" ) {
+        sampleAdapter = std::unique_ptr<SampleAdapter>(new ComplexS8SampleAdapter());
+    }
+    else if( suffix == "cu8" ) {
+        sampleAdapter = std::unique_ptr<SampleAdapter>(new ComplexU8SampleAdapter());
+    }
+    else {
+        throw std::runtime_error("Invalid file extension");
+    }
+
     FILE *file = fopen(filename, "rb");
     if (file == nullptr)
         throw std::runtime_error("Error opening file");

--- a/inputsource.cpp
+++ b/inputsource.cpp
@@ -125,9 +125,9 @@ void InputSource::openFile(const char *filename)
     if (fstat(fileno(file), &sb) != 0)
         throw std::runtime_error("Error fstating file");
     off_t size = sb.st_size;
-    sampleCount = size / sizeof(std::complex<float>);
+    sampleCount = size / sampleAdapter->sampleSize();
 
-    auto data = (std::complex<float>*)mmap(NULL, size, PROT_READ, MAP_SHARED, fileno(file), 0);
+    auto data = mmap(NULL, size, PROT_READ, MAP_SHARED, fileno(file), 0);
     if (data == nullptr)
         throw std::runtime_error("Error mmapping file");
 
@@ -166,6 +166,7 @@ std::unique_ptr<std::complex<float>[]> InputSource::getSamples(off_t start, off_
         return nullptr;
 
     std::unique_ptr<std::complex<float>[]> dest(new std::complex<float>[length]);
-    memcpy(dest.get(), &mmapData[start], length * sizeof(std::complex<float>));
+    sampleAdapter->copyRange(mmapData, start, length, dest.get());
+
     return dest;
 }

--- a/inputsource.h
+++ b/inputsource.h
@@ -36,7 +36,7 @@ private:
     off_t fileSize = 0;
     off_t sampleCount = 0;
     off_t sampleRate = 0;
-    std::complex<float> *mmapData = nullptr;
+    void *mmapData = nullptr;
     std::unique_ptr<SampleAdapter> sampleAdapter;
 
 public:

--- a/inputsource.h
+++ b/inputsource.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2015, Mike Walters <mike@flomp.net>
+ *  Copyright (C) 2015, Jared Boone <jared@sharebrained.com>
  *
  *  This file is part of inspectrum.
  *
@@ -22,6 +23,12 @@
 #include <complex>
 #include "samplesource.h"
 
+class SampleAdapter {
+public:
+    virtual size_t sampleSize() = 0;
+    virtual void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) = 0;
+};
+
 class InputSource : public SampleSource<std::complex<float>>
 {
 private:
@@ -30,6 +37,7 @@ private:
     off_t sampleCount = 0;
     off_t sampleRate = 0;
     std::complex<float> *mmapData = nullptr;
+    std::unique_ptr<SampleAdapter> sampleAdapter;
 
 public:
     InputSource();

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2015, Mike Walters <mike@flomp.net>
+ *  Copyright (C) 2015, Jared Boone <jared@sharebrained.com>
  *
  *  This file is part of inspectrum.
  *
@@ -125,7 +126,7 @@ void SpectrogramControls::fftOrZoomChanged(int value)
 void SpectrogramControls::fileOpenButtonClicked()
 {
     QString fileName = QFileDialog::getOpenFileName(
-                           this, tr("Open File"), "", tr("Sample file (*.cfile *.bin);;All files (*)")
+                           this, tr("Open File"), "", tr("complex<float> file (*.cfile *.cf32);;complex<int8> HackRF file (*.cs8);;complex<uint8> RTL-SDR file (*.cu8);;All files (*)")
                        );
     if (!fileName.isEmpty())
         emit openFile(fileName);


### PR DESCRIPTION
Updated to miek's master. Supports complex\<float32\>, complex\<uint8_t\> (RTL-SDR), and complex\<int8_t\> (HackRF) based on file extension. Now uses a "SampleAdapter" virtual class to make it a bit easier to extend -- instead of maintaining case statements in multiple places.