### PR TITLE
Fix compilation error on OS X

### DIFF
--- a/samplebuffer.cpp
+++ b/samplebuffer.cpp
@@ -37,7 +37,7 @@ template <typename Tin, typename Tout>
 std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(off_t start, off_t length)
 {
     // TODO: base this on the actual history required
-    auto history = std::min(start, 256L);
+    auto history = std::min(start, (off_t)256);
     auto samples = src->getSamples(start - history, length + history);
     if (samples == nullptr)
     	return nullptr;


### PR DESCRIPTION
On OS X the `off_t` claims to be a long long, and the definition of `min` complains about conflicting types:

```
candidate template ignored: deduced conflicting types for parameter '_Tp' ('long long' vs. 'long')
min(const _Tp& __a, const _Tp& __b)
```