### PR TITLE
Export Menu Option

### DIFF
--- a/inputsource.h
+++ b/inputsource.h
@@ -50,4 +50,7 @@ public:
     };
     void setSampleRate(off_t rate);
     off_t rate();
+    float relativeBandwidth() {
+        return 1;
+    }
 };

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -248,7 +248,7 @@ void PlotView::exportSamples(std::shared_ptr<AbstractSampleSource> src)
 
     QGroupBox groupBox2("Decimation");
     QSpinBox decimation(&groupBox2);
-    decimation.setValue(1);
+    decimation.setValue(1 / complexSrc->relativeBandwidth());
 
     QVBoxLayout vbox2;
     vbox2.addWidget(&decimation);

--- a/plotview.h
+++ b/plotview.h
@@ -80,6 +80,7 @@ private:
     void addPlot(Plot *plot);
     void emitTimeSelection();
     void extractSymbols(std::shared_ptr<AbstractSampleSource> src);
+    void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     int plotsHeight();
     off_t samplesPerLine();
     void updateView(bool reCenter = false);

--- a/samplebuffer.h
+++ b/samplebuffer.h
@@ -43,4 +43,8 @@ public:
     off_t rate() {
         return src->rate();
     };
+
+    float relativeBandwidth() {
+        return 1;
+    }
 };

--- a/samplesource.h
+++ b/samplesource.h
@@ -36,6 +36,7 @@ public:
     virtual void invalidateEvent() { };
     virtual off_t count() = 0;
     virtual off_t rate() = 0;
+    virtual float relativeBandwidth() = 0;
     std::type_index sampleType() override;
     void subscribe(Subscriber *subscriber);
     int subscriberCount();

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -34,7 +34,7 @@
 SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), tuner(this)
 {
     setFFTSize(512);
-    zoomLevel = 0;
+    zoomLevel = 1;
     powerMax = 0.0f;
     powerMin = -50.0f;
 
@@ -236,6 +236,7 @@ void SpectrogramPlot::tunerMoved()
 {
     tunerTransform->setFrequency(getTunerPhaseInc());
     tunerTransform->setTaps(getTunerTaps());
+    tunerTransform->setRelativeBandwith(tuner.deviation() * 2.0 / getStride());
 
     // TODO: for invalidating traceplot cache, this shouldn't really go here
     QPixmapCache::clear();

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -45,7 +45,6 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
 
     tunerTransform = std::make_shared<TunerTransform>(src.get());
     connect(&tuner, &Tuner::tunerMoved, this, &SpectrogramPlot::tunerMoved);
-    tunerMoved();
     src->subscribe(this);
 }
 

--- a/tunertransform.cpp
+++ b/tunertransform.cpp
@@ -21,7 +21,7 @@
 #include <liquid/liquid.h>
 #include "util.h"
 
-TunerTransform::TunerTransform(SampleSource<std::complex<float>> *src) : SampleBuffer(src), taps{1.0f}
+TunerTransform::TunerTransform(SampleSource<std::complex<float>> *src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
 {
 
 }

--- a/tunertransform.cpp
+++ b/tunertransform.cpp
@@ -61,3 +61,13 @@ void TunerTransform::setTaps(std::vector<float> taps)
 {
     this->taps = taps;
 }
+
+float TunerTransform::relativeBandwidth() {
+    return bandwidth;
+}
+
+void TunerTransform::setRelativeBandwith(float bandwidth)
+{
+    this->bandwidth = bandwidth;
+}
+

--- a/tunertransform.h
+++ b/tunertransform.h
@@ -27,10 +27,13 @@ class TunerTransform : public SampleBuffer<std::complex<float>, std::complex<flo
 private:
     float frequency;
     std::vector<float> taps;
+    float bandwidth;
 
 public:
     TunerTransform(SampleSource<std::complex<float>> *src);
     void work(void *input, void *output, int count, off_t sampleid) override;
     void setFrequency(float frequency);
     void setTaps(std::vector<float> taps);
+    void setRelativeBandwith(float bandwidth);
+    float relativeBandwidth();
 };


### PR DESCRIPTION
This adds a menu option to export (filtered) samples from a file.

![screenshot from 2016-09-01 00 50 26](https://cloud.githubusercontent.com/assets/452051/18150375/262e6dbc-6fde-11e6-8d51-d62a85f319c2.png)

If a tuner is activated (by adding a derived plot which uses it), the filtered samples will be used. The dialogue makes a recommendation for the decimation, based on the filter width.

Full file export uses multiple calls to `SampleBuffer::getSamples()` which leads do small discontinuities in the output file. I think this should be fixed in `SampleBuffer::getSamples()`. This is why I've added the experimental label to the option.

If cursors are activated, an option to only export the cursor selection is activated.

Things which should be improved (not necessarily in the PR):
 - The FIR filter length is constant and sometimes not large enough for good results
 - The complete file export is not "perfect"
 - The recommended decimation might have an odd/unusual value
 - Maybe there is a nicer and less invasive way to determine the decimation

Closes https://github.com/miek/inspectrum/issues/49