### PR TITLE
Add Decimation Slider (zoom out)

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -40,7 +40,7 @@ MainWindow::MainWindow()
     // Connect dock inputs
     connect(dock, SIGNAL(openFile(QString)), this, SLOT(openFile(QString)));
     connect(dock->sampleRate, SIGNAL(textChanged(QString)), this, SLOT(setSampleRate(QString)));
-    connect(dock, SIGNAL(fftOrZoomChanged(int, int)), plots, SLOT(setFFTAndZoom(int, int)));
+    connect(dock, SIGNAL(fftOrZoomChanged(int, int, int)), plots, SLOT(setFFTAndZoom(int, int, int)));
     connect(dock->powerMaxSlider, SIGNAL(valueChanged(int)), plots, SLOT(setPowerMax(int)));
     connect(dock->powerMinSlider, SIGNAL(valueChanged(int)), plots, SLOT(setPowerMin(int)));
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -259,7 +259,7 @@ void PlotView::exportSamples(std::shared_ptr<AbstractSampleSource> src)
 
     if (dialog.exec()) {
         QStringList fileNames = dialog.selectedFiles();
-       
+
         off_t start, end;
         if (cursorSelection.isChecked()) {
             start = selectedSamples.minimum;
@@ -279,7 +279,7 @@ void PlotView::exportSamples(std::shared_ptr<AbstractSampleSource> src)
         off_t step = viewRange.length();
 
         for (index = start; index < end; index += step) {
-            off_t length = std::min(step, end - index); 
+            off_t length = std::min(step, end - index);
             auto samples = complexSrc->getSamples(index, length);
             if (samples != nullptr) {
                 for (auto i = 0; i < length; i += decimation.value()) {
@@ -314,7 +314,7 @@ void PlotView::setCursorSegments(int segments)
     emitTimeSelection();
 }
 
-void PlotView::setFFTAndZoom(int size, int zoom)
+void PlotView::setFFTAndZoom(int size, int zoom, int decim)
 {
     // Set new FFT size
     fftSize = size;
@@ -326,9 +326,14 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     if (spectrogramPlot != nullptr)
         spectrogramPlot->setZoomLevel(zoom);
 
+    // Set new zoom level
+    decimLevel = decim;
+    if (spectrogramPlot != nullptr)
+        spectrogramPlot->setDecimLevel(decim);
+
     // Update horizontal (time) scrollbar
-    horizontalScrollBar()->setSingleStep(size * 10 / zoomLevel);
-    horizontalScrollBar()->setPageStep(size * 100 / zoomLevel);
+    horizontalScrollBar()->setSingleStep(size * 10 * decimLevel / zoomLevel);
+    horizontalScrollBar()->setPageStep(size * 100 * decimLevel / zoomLevel);
 
     updateView(true);
 }
@@ -512,4 +517,3 @@ void PlotView::enableScales(bool enabled)
 
     viewport()->update();
 }
-

--- a/plotview.h
+++ b/plotview.h
@@ -49,7 +49,7 @@ public slots:
     void invalidateEvent();
     void repaint();
     void setCursorSegments(int segments);
-    void setFFTAndZoom(int fftSize, int zoomLevel);
+    void setFFTAndZoom(int fftSize, int zoomLevel, int decimLevel);
     void setPowerMin(int power);
     void setPowerMax(int power);
 
@@ -71,6 +71,7 @@ private:
 
     int fftSize = 1024;
     int zoomLevel = 0;
+    int decimLevel = 1;
     int powerMin;
     int powerMax;
     bool cursorsEnabled;

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -54,6 +54,13 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     layout->addRow(new QLabel(tr("Zoom:")), zoomLevelSlider);
 
+
+    decimLevelSlider = new QSlider(Qt::Horizontal, widget);
+    decimLevelSlider->setRange(1, 50);
+    decimLevelSlider->setPageStep(1);
+    layout->addRow(new QLabel(tr("Decimation:")), decimLevelSlider);
+
+
     powerMaxSlider = new QSlider(Qt::Horizontal, widget);
     powerMaxSlider->setRange(-140, 10);
     layout->addRow(new QLabel(tr("Power max:")), powerMaxSlider);
@@ -95,6 +102,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     connect(fftSizeSlider, SIGNAL(valueChanged(int)), this, SLOT(fftOrZoomChanged(int)));
     connect(zoomLevelSlider, SIGNAL(valueChanged(int)), this, SLOT(fftOrZoomChanged(int)));
+    connect(decimLevelSlider, SIGNAL(valueChanged(int)), this, SLOT(fftOrZoomChanged(int)));
     connect(fileOpenButton, SIGNAL(clicked()), this, SLOT(fileOpenButtonClicked()));
     connect(cursorsCheckBox, SIGNAL(stateChanged(int)), this, SLOT(cursorsStateChanged(int)));
 }
@@ -119,6 +127,7 @@ void SpectrogramControls::setDefaults()
     sampleRate->setText("8000000");
     fftSizeSlider->setValue(9);
     zoomLevelSlider->setValue(0);
+    decimLevelSlider->setValue(1);
     powerMaxSlider->setValue(0);
     powerMinSlider->setValue(-100);
     cursorsCheckBox->setCheckState(Qt::Unchecked);
@@ -129,7 +138,8 @@ void SpectrogramControls::fftOrZoomChanged(int value)
 {
     int fftSize = pow(2, fftSizeSlider->value());
     int zoomLevel = std::min(fftSize, (int)pow(2, zoomLevelSlider->value()));
-    emit fftOrZoomChanged(fftSize, zoomLevel);
+    int decimLevel = std::min(fftSize, (int)pow(2, decimLevelSlider->value()));
+    emit fftOrZoomChanged(fftSize, zoomLevel, decimLevel);
 }
 
 void SpectrogramControls::fileOpenButtonClicked()

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -56,7 +56,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
 
     decimLevelSlider = new QSlider(Qt::Horizontal, widget);
-    decimLevelSlider->setRange(1, 50);
+    decimLevelSlider->setRange(1, 20);
     decimLevelSlider->setPageStep(1);
     layout->addRow(new QLabel(tr("Decimation:")), decimLevelSlider);
 

--- a/spectrogramcontrols.h
+++ b/spectrogramcontrols.h
@@ -37,7 +37,7 @@ public:
     void setDefaults();
 
 signals:
-    void fftOrZoomChanged(int fftSize, int zoomLevel);
+    void fftOrZoomChanged(int fftSize, int zoomLevel, int decimLevel);
     void openFile(QString fileName);
 
 public slots:
@@ -60,6 +60,7 @@ public:
     QLineEdit *sampleRate;
     QSlider *fftSizeSlider;
     QSlider *zoomLevelSlider;
+    QSlider *decimLevelSlider;
     QSlider *powerMaxSlider;
     QSlider *powerMinSlider;
     QCheckBox *cursorsCheckBox;

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -191,10 +191,12 @@ float* SpectrogramPlot::getFFTTile(off_t tile)
     if (obj != 0)
         return obj;
 
-    float *dest = new float[tileSize];
+    //float *dest = new float[tileSize];
+    float *dest = new float[fftSize];
     float *ptr = dest;
     off_t sample = tile;
-    while ((ptr - dest) < tileSize) {
+    //while ((ptr - dest) < tileSize) {
+    while ((ptr - dest) < fftSize) {
         getLine(ptr, sample);
         sample += getStride();
         ptr += fftSize;
@@ -232,7 +234,7 @@ void SpectrogramPlot::getLine(float *dest, off_t sample)
 
 int SpectrogramPlot::getStride()
 {
-    return fftSize / zoomLevel;
+    return fftSize * decimLevel / (zoomLevel);
 }
 
 float SpectrogramPlot::getTunerPhaseInc()
@@ -256,7 +258,8 @@ std::vector<float> SpectrogramPlot::getTunerTaps()
 
 int SpectrogramPlot::linesPerTile()
 {
-    return tileSize / fftSize;
+    //return tileSize / fftSize;
+    return 1;
 }
 
 bool SpectrogramPlot::mouseEvent(QEvent::Type type, QMouseEvent event)
@@ -301,6 +304,11 @@ void SpectrogramPlot::setPowerMin(int power)
 void SpectrogramPlot::setZoomLevel(int zoom)
 {
     zoomLevel = zoom;
+}
+
+void SpectrogramPlot::setDecimLevel(int decim)
+{
+    decimLevel = decim;
 }
 
 void SpectrogramPlot::setSampleRate(off_t rate)

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -51,6 +51,7 @@ public slots:
     void setPowerMax(int power);
     void setPowerMin(int power);
     void setZoomLevel(int zoom);
+    void setDecimLevel(int decim);
     void tunerMoved();
 
 private:
@@ -66,6 +67,7 @@ private:
 
     int fftSize;
     int zoomLevel;
+    int decimLevel;
     float powerMax;
     float powerMin;
     off_t sampleRate;


### PR DESCRIPTION
Hi Miek, great tool. I normally use baudline for this type of thing, but baudline is not great for viewing large datasets, which is something I do frequently. So, I added the ability to zoom out (decimate) the number of FFTs for viewing data within larger files. I have found this very helpful and wanted to offer the change to you, however it changes some things you may not like:

1) Adds a slider for decimation. Perhaps this should be incorporated into the zoom slider directly? Not sure. I did this because I can be sure where both the decimation AND zoom are set, and that there is zero decimation.

2) This actually decimates tiles, which causes large discontinuities if the _linesPerTile_ value is large. So I forced the _tileSize_ to the _fftSize_. Maybe I should not do this? I did not notice a performance impact on my development VM but who knows. Im sure that it could be reworked to still use larger tiles.

I know nothing about QT, and am an RF guy before software developer so feel free to reject or if you think it's useful suggest changes and I'll see if I can do it.

Jacob