### PR TITLE
Fixes for various crashes

### DIFF
--- a/amplitudedemod.cpp
+++ b/amplitudedemod.cpp
@@ -19,7 +19,7 @@
 
 #include "amplitudedemod.h"
 
-AmplitudeDemod::AmplitudeDemod(SampleSource<std::complex<float>> *src) : SampleBuffer(src)
+AmplitudeDemod::AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
 
 }

--- a/amplitudedemod.h
+++ b/amplitudedemod.h
@@ -24,6 +24,6 @@
 class AmplitudeDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
-    AmplitudeDemod(SampleSource<std::complex<float>> *src);
+    AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, off_t sampleid) override;
 };

--- a/frequencydemod.cpp
+++ b/frequencydemod.cpp
@@ -21,7 +21,7 @@
 #include <liquid/liquid.h>
 #include "util.h"
 
-FrequencyDemod::FrequencyDemod(SampleSource<std::complex<float>> *src) : SampleBuffer(src)
+FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src)
 {
 
 }

--- a/frequencydemod.h
+++ b/frequencydemod.h
@@ -24,6 +24,6 @@
 class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
-    FrequencyDemod(SampleSource<std::complex<float>> *src);
+    FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, off_t sampleid) override;
 };

--- a/plots.cpp
+++ b/plots.cpp
@@ -34,25 +34,21 @@ Plot* Plots::samplePlot(std::shared_ptr<AbstractSampleSource> source)
 
 Plot* Plots::amplitudePlot(std::shared_ptr<AbstractSampleSource> source)
 {
-    typedef SampleSource<std::complex<float>> ss;
-    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
-    return new TracePlot(
-        std::make_shared<AmplitudeDemod>(cs)
-    );
+    typedef SampleSource<std::complex<float>> Source;
+    std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
+    return new TracePlot( std::make_shared<AmplitudeDemod>(concrete) );
 }
 
 Plot* Plots::frequencyPlot(std::shared_ptr<AbstractSampleSource> source)
 {
-    typedef SampleSource<std::complex<float>> ss;
-    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
-    return new TracePlot(
-        std::make_shared<FrequencyDemod>(cs)
-    );
+    typedef SampleSource<std::complex<float>> Source;
+    std::shared_ptr<Source> concrete = std::dynamic_pointer_cast<Source>(source);
+    return new TracePlot( std::make_shared<FrequencyDemod>( concrete ) );
 }
 
 Plot* Plots::thresholdPlot(std::shared_ptr<AbstractSampleSource> source)
 {
-    typedef SampleSource<float> ss;
-    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
-    return new TracePlot( std::make_shared<Threshold>( cs ) );
+    typedef SampleSource<float> Source;
+    std::shared_ptr<Source> concrete= std::dynamic_pointer_cast<Source>(source);
+    return new TracePlot( std::make_shared<Threshold>( concrete ) );
 }

--- a/plots.cpp
+++ b/plots.cpp
@@ -34,27 +34,25 @@ Plot* Plots::samplePlot(std::shared_ptr<AbstractSampleSource> source)
 
 Plot* Plots::amplitudePlot(std::shared_ptr<AbstractSampleSource> source)
 {
+    typedef SampleSource<std::complex<float>> ss;
+    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
     return new TracePlot(
-        std::make_shared<AmplitudeDemod>(
-            std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(source).get()
-        )
+        std::make_shared<AmplitudeDemod>(cs)
     );
 }
 
 Plot* Plots::frequencyPlot(std::shared_ptr<AbstractSampleSource> source)
 {
+    typedef SampleSource<std::complex<float>> ss;
+    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
     return new TracePlot(
-        std::make_shared<FrequencyDemod>(
-            std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(source).get()
-        )
+        std::make_shared<FrequencyDemod>(cs)
     );
 }
 
 Plot* Plots::thresholdPlot(std::shared_ptr<AbstractSampleSource> source)
 {
-    return new TracePlot(
-        std::make_shared<Threshold>(
-            std::dynamic_pointer_cast<SampleSource<float>>(source).get()
-        )
-    );
+    typedef SampleSource<float> ss;
+    std::shared_ptr<ss> cs = std::dynamic_pointer_cast<ss>(source);
+    return new TracePlot( std::make_shared<Threshold>( cs ) );
 }

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -113,8 +113,9 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
     save->setEnabled(src->sampleType() == typeid(std::complex<float>));
     menu.addAction(save);
 
-    updateView(false);
-    menu.exec(event->globalPos());
+    updateViewRange(false);
+    if(menu.exec(event->globalPos()))
+        updateView(false);
 }
 
 void PlotView::cursorsMoved()
@@ -459,7 +460,7 @@ void PlotView::scrollContentsBy(int dx, int dy)
     updateView();
 }
 
-void PlotView::updateView(bool reCenter)
+void PlotView::updateViewRange(bool reCenter)
 {
     // Store old view for recentering
     auto oldViewRange = viewRange;
@@ -476,7 +477,11 @@ void PlotView::updateView(bool reCenter)
             horizontalScrollBar()->value() + (oldViewRange.length() - viewRange.length()) / 2
         );
     }
+}
 
+void PlotView::updateView(bool reCenter)
+{
+    updateViewRange(reCenter);
     horizontalScrollBar()->setMaximum(std::max(off_t(0), mainSampleSource->count() - ((width() - 1) * samplesPerLine())));
 
     verticalScrollBar()->setMaximum(std::max(0, plotsHeight() - viewport()->height()));

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -113,8 +113,8 @@ void PlotView::contextMenuEvent(QContextMenuEvent * event)
     save->setEnabled(src->sampleType() == typeid(std::complex<float>));
     menu.addAction(save);
 
-    if (menu.exec(event->globalPos()))
-        updateView(false);
+    updateView(false);
+    menu.exec(event->globalPos());
 }
 
 void PlotView::cursorsMoved()

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -482,7 +482,6 @@ void PlotView::updateView(bool reCenter)
     verticalScrollBar()->setMaximum(std::max(0, plotsHeight() - viewport()->height()));
 
     // Update cursors
-    QRect rect = viewport()->rect();
     range_t<int> newSelection = {
         (int)((selectedSamples.minimum - horizontalScrollBar()->value()) / samplesPerLine()),
         (int)((selectedSamples.maximum - horizontalScrollBar()->value()) / samplesPerLine())

--- a/plotview.h
+++ b/plotview.h
@@ -67,7 +67,6 @@ private:
     std::vector<std::unique_ptr<Plot>> plots;
     range_t<off_t> viewRange;
     range_t<off_t> selectedSamples;
-    std::pair<float, float> selectionFreq;
 
     int fftSize = 1024;
     int zoomLevel = 0;

--- a/plotview.h
+++ b/plotview.h
@@ -82,6 +82,7 @@ private:
     void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     int plotsHeight();
     off_t samplesPerLine();
+    void updateViewRange(bool reCenter);
     void updateView(bool reCenter = false);
     void paintTimeScale(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
 };

--- a/samplebuffer.cpp
+++ b/samplebuffer.cpp
@@ -22,7 +22,7 @@
 #include "samplebuffer.h"
 
 template <typename Tin, typename Tout>
-SampleBuffer<Tin, Tout>::SampleBuffer(SampleSource<Tin> *src) : src(src)
+SampleBuffer<Tin, Tout>::SampleBuffer(std::shared_ptr<SampleSource<Tin>> src) : src(src)
 {
 	src->subscribe(this);
 }

--- a/samplebuffer.h
+++ b/samplebuffer.h
@@ -28,11 +28,11 @@ template <typename Tin, typename Tout>
 class SampleBuffer : public SampleSource<Tout>, public Subscriber
 {
 private:
-    SampleSource<Tin> *src;
+    std::shared_ptr<SampleSource<Tin>> src;
     QMutex mutex;
 
 public:
-    SampleBuffer(SampleSource<Tin> *src);
+    SampleBuffer(std::shared_ptr<SampleSource<Tin>> src);
     ~SampleBuffer();
     void invalidateEvent();
     virtual std::unique_ptr<Tout[]> getSamples(off_t start, off_t length);

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -45,7 +45,7 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
         colormap[i] = QColor::fromHsvF(p * 0.83f, 1.0, 1.0 - p).rgba();
     }
 
-    tunerTransform = std::make_shared<TunerTransform>(src.get());
+    tunerTransform = std::make_shared<TunerTransform>(src);
     connect(&tuner, &Tuner::tunerMoved, this, &SpectrogramPlot::tunerMoved);
     src->subscribe(this);
 }

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -187,20 +187,20 @@ QPixmap* SpectrogramPlot::getPixmapTile(off_t tile)
 
 float* SpectrogramPlot::getFFTTile(off_t tile)
 {
-    float *obj = fftCache.object(TileCacheKey(fftSize, zoomLevel, tile));
-    if (obj != 0)
-        return obj;
+    std::array<float, tileSize>* obj = fftCache.object(TileCacheKey(fftSize, zoomLevel, tile));
+    if (obj != nullptr)
+        return obj->data();
 
-    float *dest = new float[tileSize];
-    float *ptr = dest;
+    std::array<float, tileSize>* destStorage = new std::array<float, tileSize>;
+    float *ptr = destStorage->data();
     off_t sample = tile;
-    while ((ptr - dest) < tileSize) {
+    while ((ptr - destStorage->data()) < tileSize) {
         getLine(ptr, sample);
         sample += getStride();
         ptr += fftSize;
     }
-    fftCache.insert(TileCacheKey(fftSize, zoomLevel, tile), dest);
-    return dest;
+    fftCache.insert(TileCacheKey(fftSize, zoomLevel, tile), destStorage);
+    return destStorage->data();
 }
 
 void SpectrogramPlot::getLine(float *dest, off_t sample)

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -31,7 +31,7 @@
 #include "util.h"
 
 
-SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), tuner(this)
+SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), fftSize(512), tuner(this)
 {
     setFFTSize(512);
     zoomLevel = 1;

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -28,6 +28,7 @@
 #include "tunertransform.h"
 
 #include <memory>
+#include <array>
 #include <math.h>
 
 class TileCacheKey;

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -55,13 +55,13 @@ public slots:
 
 private:
     const int linesPerGraduation = 50;
-    const int tileSize = 65536; // This must be a multiple of the maximum FFT size
+    static const int tileSize = 65536; // This must be a multiple of the maximum FFT size
 
     std::shared_ptr<SampleSource<std::complex<float>>> inputSource;
     std::unique_ptr<FFT> fft;
     std::unique_ptr<float[]> window;
     QCache<TileCacheKey, QPixmap> pixmapCache;
-    QCache<TileCacheKey, float> fftCache;
+    QCache<TileCacheKey, std::array<float, tileSize>> fftCache;
     uint colormap[256];
 
     int fftSize;

--- a/threshold.cpp
+++ b/threshold.cpp
@@ -19,7 +19,7 @@
 
 #include "threshold.h"
 
-Threshold::Threshold(SampleSource<float> *src) : SampleBuffer(src)
+Threshold::Threshold(std::shared_ptr<SampleSource<float>> src) : SampleBuffer(src)
 {
 
 }

--- a/threshold.h
+++ b/threshold.h
@@ -24,6 +24,6 @@
 class Threshold : public SampleBuffer<float, float>
 {
 public:
-    Threshold(SampleSource<float> *src);
+    Threshold(std::shared_ptr<SampleSource<float>> src);
     void work(void *input, void *output, int count, off_t sampleid) override;
 };

--- a/tunertransform.cpp
+++ b/tunertransform.cpp
@@ -28,7 +28,6 @@ TunerTransform::TunerTransform(SampleSource<std::complex<float>> *src) : SampleB
 
 void TunerTransform::work(void *input, void *output, int count, off_t sampleid)
 {
-    auto in = static_cast<std::complex<float>*>(input);
     auto out = static_cast<std::complex<float>*>(output);
     std::unique_ptr<std::complex<float>[]> temp(new std::complex<float>[count]);
 

--- a/tunertransform.cpp
+++ b/tunertransform.cpp
@@ -21,7 +21,7 @@
 #include <liquid/liquid.h>
 #include "util.h"
 
-TunerTransform::TunerTransform(SampleSource<std::complex<float>> *src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
+TunerTransform::TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src) : SampleBuffer(src), frequency(0), bandwidth(1.), taps{1.0f}
 {
 
 }

--- a/tunertransform.h
+++ b/tunertransform.h
@@ -26,8 +26,8 @@ class TunerTransform : public SampleBuffer<std::complex<float>, std::complex<flo
 {
 private:
     float frequency;
-    std::vector<float> taps;
     float bandwidth;
+    std::vector<float> taps;
 
 public:
     TunerTransform(SampleSource<std::complex<float>> *src);

--- a/tunertransform.h
+++ b/tunertransform.h
@@ -30,7 +30,7 @@ private:
     std::vector<float> taps;
 
 public:
-    TunerTransform(SampleSource<std::complex<float>> *src);
+    TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void work(void *input, void *output, int count, off_t sampleid) override;
     void setFrequency(float frequency);
     void setTaps(std::vector<float> taps);


### PR DESCRIPTION
A couple of fixes for problems I encountered:

* Infinite loop when attempting to export samples without having scrolled the spectrum display
* Memory leak freeing cached tiles
* Use-after-free on sample sources during shutdown
* Tidy a couple of compiler warnings.