### PR TITLE
Adding checkbox to enable linking of cursors

### DIFF
--- a/cursor.cpp
+++ b/cursor.cpp
@@ -63,8 +63,9 @@ bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent event)
     // Update current cursor positon if we're dragging
     } else if (type == QEvent::MouseMove) {
         if (dragging) {
-            cursorPosition = fromPoint(event.pos());
-            emit posChanged();
+            int cursorPositionNew = fromPoint(event.pos());
+            emit posChanged(cursorPositionNew - cursorPosition);
+            cursorPosition = cursorPositionNew;
         }
 
     // Stop dragging on left mouse button release

--- a/cursor.h
+++ b/cursor.h
@@ -35,7 +35,7 @@ public:
     bool mouseEvent(QEvent::Type type, QMouseEvent event);
 
 signals:
-    void posChanged();
+    void posChanged(int delta);
 
 private:
     int fromPoint(QPoint point);

--- a/cursors.h
+++ b/cursors.h
@@ -37,19 +37,22 @@ public:
     void paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
     range_t<int> selection();
     void setSegments(int segments);
+    void setCursorsLinked(bool linked);
     void setSelection(range_t<int> selection);
 
 public slots:
-	void cursorMoved();
+    void minCursorMoved(int delta);
+    void maxCursorMoved(int delta);
 
 signals:
-	void cursorsMoved();
-
+    void cursorsMoved();
 
 private:
-	bool pointOverCursor(QPoint point, int &cursor);
+    bool pointOverCursor(QPoint point, int &cursor);
+    void swapIfNegative();
 
-	Cursor *minCursor;
-	Cursor *maxCursor;
-	int segmentCount = 1;
+    Cursor *minCursor;
+    Cursor *maxCursor;
+    int segmentCount = 1;
+    bool cursorsLinked = false;
 };

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -44,6 +44,7 @@ MainWindow::MainWindow()
     connect(dock->powerMaxSlider, SIGNAL(valueChanged(int)), plots, SLOT(setPowerMax(int)));
     connect(dock->powerMinSlider, SIGNAL(valueChanged(int)), plots, SLOT(setPowerMin(int)));
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);
+    connect(dock->cursorsLinkedCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursorsLinked);
     connect(dock->scalesCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableScales);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -146,6 +146,11 @@ void PlotView::enableCursors(bool enabled)
     viewport()->update();
 }
 
+void PlotView::enableCursorsLinked(bool enabled)
+{
+    cursors.setCursorsLinked(enabled);
+}
+
 bool PlotView::eventFilter(QObject * obj, QEvent *event)
 {
     // Pass mouse events to individual plot objects

--- a/plotview.h
+++ b/plotview.h
@@ -45,6 +45,7 @@ signals:
 public slots:
     void cursorsMoved();
     void enableCursors(bool enabled);
+    void enableCursorsLinked(bool enabled);
     void enableScales(bool enabled);
     void invalidateEvent();
     void repaint();

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -74,6 +74,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("Enable cursors:")), cursorsCheckBox);
 
     cursorsLinkedCheckBox = new QCheckBox(widget);
+    cursorsLinkedCheckBox->setEnabled(false);
     layout->addRow(new QLabel(tr("Link cursors:")), cursorsLinkedCheckBox);
 
     cursorSymbolsSpinBox = new QSpinBox();
@@ -112,6 +113,7 @@ void SpectrogramControls::clearCursorLabels()
 
 void SpectrogramControls::cursorsStateChanged(int state)
 {
+    cursorsLinkedCheckBox->setEnabled(cursorsCheckBox->isChecked());
     if (state == Qt::Unchecked) {
         clearCursorLabels();
     }

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -73,6 +73,9 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     cursorsCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Enable cursors:")), cursorsCheckBox);
 
+    cursorsLinkedCheckBox = new QCheckBox(widget);
+    layout->addRow(new QLabel(tr("Link cursors:")), cursorsLinkedCheckBox);
+
     cursorSymbolsSpinBox = new QSpinBox();
     cursorSymbolsSpinBox->setMinimum(1);
     cursorSymbolsSpinBox->setMaximum(9999);

--- a/spectrogramcontrols.h
+++ b/spectrogramcontrols.h
@@ -63,6 +63,7 @@ public:
     QSlider *powerMaxSlider;
     QSlider *powerMinSlider;
     QCheckBox *cursorsCheckBox;
+    QCheckBox *cursorsLinkedCheckBox;
     QSpinBox *cursorSymbolsSpinBox;
     QLabel *rateLabel;
     QLabel *periodLabel;


### PR DESCRIPTION
Hey there, I implemented a small change that I thought might come in handy. It provides the functionality to link the selection cursors to each other. When one of them is moved, the other moves accordingly.