### PR TITLE
Minor UI tweaks

### DIFF
--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -78,6 +78,10 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
 
     int bwPerTick = 10 * pow(10, floor(log(bwPerPixel * tickHeight) / log(10)));
 
+    if (bwPerTick >= sampleRate / 2) {
+        bwPerTick /= 10;
+    }
+
     if (bwPerTick < 1) {
         return;
     }

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -33,7 +33,7 @@
 
 SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), fftSize(512), tuner(this)
 {
-    setFFTSize(512);
+    setFFTSize(fftSize);
     zoomLevel = 1;
     powerMax = 0.0f;
     powerMin = -50.0f;
@@ -278,6 +278,7 @@ std::shared_ptr<AbstractSampleSource> SpectrogramPlot::output()
 
 void SpectrogramPlot::setFFTSize(int size)
 {
+    float sizeScale = float(size) / float(fftSize);
     fftSize = size;
     fft.reset(new FFT(fftSize));
 
@@ -287,6 +288,8 @@ void SpectrogramPlot::setFFTSize(int size)
     }
 
     setHeight(fftSize);
+    tuner.setDeviation( tuner.deviation() * sizeScale );
+    tuner.setCentre( tuner.centre() * sizeScale );
 }
 
 void SpectrogramPlot::setPowerMax(int power)


### PR DESCRIPTION
Small changes to improve UI/navigation.

* If the sample rate was a power of 10, no ticks would be shown previously.
* Try to keep the tuner at the same spot when the FFT size changes.