### PR TITLE
Enable movement of both cursors by dragging between them

### DIFF
--- a/cursors.cpp
+++ b/cursors.cpp
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QApplication>
 #include <QDebug>
 #include "cursors.h"
 
@@ -37,14 +38,58 @@ void Cursors::cursorMoved()
     emit cursorsMoved();
 }
 
+bool Cursors::pointWithinDragRegion(QPoint point) {
+    int margin = 10;
+    range_t<int> range = {minCursor->pos()+margin, maxCursor->pos()-margin};
+    return range.contains(point.x());
+}
+
 bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent event)
 {
     if (minCursor->mouseEvent(type, event))
         return true;
     if (maxCursor->mouseEvent(type, event))
-        return true;
+	return true;
 
-    return false;
+    // If the mouse pointer is between the cursors, display a resize pointer
+    if (pointWithinDragRegion(event.pos()) && type != QEvent::Leave) {
+	if (!cursorOverride) {
+            cursorOverride = true;
+            QApplication::setOverrideCursor(QCursor(Qt::SizeAllCursor));
+	}
+    // Restore pointer otherwise
+    } else {
+	if (cursorOverride) {
+	    cursorOverride = false;
+	    QApplication::restoreOverrideCursor();
+	}
+    }
+    // Start dragging on left mouse button press, if between the cursors
+    if (type == QEvent::MouseButtonPress) {
+        if (event.button() == Qt::LeftButton) {
+            if (pointWithinDragRegion(event.pos())) {
+                dragging = true;
+		dragPos = event.pos();
+                return true;
+            }
+        }
+    // Update both cursor positons if we're dragging
+    } else if (type == QEvent::MouseMove) {
+        if (dragging) {
+	    int dx = event.pos().x() - dragPos.x();
+            minCursor->setPos(minCursor->pos() + dx);
+            maxCursor->setPos(maxCursor->pos() + dx);
+	    dragPos = event.pos();
+            emit cursorsMoved();
+        }
+    // Stop dragging on left mouse button release
+    } else if (type == QEvent::MouseButtonRelease) {
+        if (event.button() == Qt::LeftButton && dragging) {
+            dragging = false;
+            return true;
+        }
+    }
+    return true;
 }
 
 void Cursors::paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)

--- a/cursors.h
+++ b/cursors.h
@@ -45,11 +45,14 @@ public slots:
 signals:
 	void cursorsMoved();
 
-
 private:
-	bool pointOverCursor(QPoint point, int &cursor);
-
+	bool pointWithinDragRegion(QPoint point);
+	
 	Cursor *minCursor;
 	Cursor *maxCursor;
 	int segmentCount = 1;
+	
+	QPoint dragPos;                // keep track of dragging distance
+        bool cursorOverride = false;   // used to record if cursor is overridden
+	bool dragging = false;         // record if mouse is dragging
 };


### PR DESCRIPTION
I reasoned about being able to move both cursors simultaneously here: https://github.com/miek/inspectrum/pull/99. The original implementation was a little cumbersome for the user.

This is a way of doing the same: If the user clicks and drags on the grey area between the enabled cursors, both cursors are moved. The cursors can still be moved individually, as before.