### PR TITLE
Widened FFT size range

### DIFF
--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -44,7 +44,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("<b>Spectrogram</b>")));
 
     fftSizeSlider = new QSlider(Qt::Horizontal, widget);
-    fftSizeSlider->setRange(7, 13);
+    fftSizeSlider->setRange(4, 16);
     fftSizeSlider->setPageStep(1);
 
     layout->addRow(new QLabel(tr("FFT size:")), fftSizeSlider);


### PR DESCRIPTION
I needed smaller FFTs to make my 1s and 0s show up as my samples-per-symbol was quite low.  I've also increased the maximum.

It would be useful if the sliders displayed a numerical value next to them, indicating what the values of the e.g. FFT size, power thresholds, etc. were.  I might add that later if I have time.