### PR TITLE
fixes a zooming bug

### DIFF
--- a/plotview.cpp
+++ b/plotview.cpp
@@ -517,15 +517,15 @@ void PlotView::updateViewRange(bool reCenter)
             sampleToColumn(zoomSample) - zoomPos
         );
     }
-    zoomSample = viewRange.minimum + viewRange.length() / 2;
-    zoomPos = width() / 2;
+    // zoomSample = viewRange.minimum + viewRange.length() / 2;
+    // zoomPos = width() / 2;
 }
 
 void PlotView::updateView(bool reCenter)
 {
-    updateViewRange(reCenter);
     horizontalScrollBar()->setMaximum(std::max(0, sampleToColumn(mainSampleSource->count()) - width()));
     verticalScrollBar()->setMaximum(std::max(0, plotsHeight() - viewport()->height()));
+    updateViewRange(reCenter);
 
     // Update cursors
     range_t<int> newSelection = {


### PR DESCRIPTION
When you try to zoom in/out after the middle point of the sample buffer the display jumps to the end of the buffer. This branch fixes that. 

Observation: there is some strange behavior of updateView, it is called recursively (from updateViewRange when horizontalScrollBar()->setValue() is called). Just guarding against the recursive call does not fix the original issue and causes some other issues, so I left that in place.