### PR TITLE
Use a DC offset of 127.4 to match the RTL-SDR.

### DIFF
--- a/inputsource.cpp
+++ b/inputsource.cpp
@@ -89,7 +89,7 @@ public:
         std::transform(&s[start], &s[start + length], dest,
             [](const std::complex<uint8_t>& v) -> std::complex<float> {
                 const float k = 1.0f / 128.0f;
-                return { v.real() * k - 1.0f, v.imag() * k - 1.0f };
+                return { (v.real() - 127.4f) * k, (v.imag() - 127.4f) * k };
             }
         );
     }


### PR DESCRIPTION
When reading samples produced by an RTL-SDR, there is a fairly noticeable DC spike. That's because the RTL-SDR has a DC offset of approximately 127.4, whereas inspectrum uses 128.0.

I suspect the cu8 format is almost always used with an RTL-SDR, so it seems like it would be worth changing the offset in inspectrum.

Here's the corresponding code in gr-osmosdr for comparison: https://github.com/osmocom/gr-osmosdr/blob/c653754dde5e2cf682965e939cc016fbddbd45e4/lib/rtl/rtl_source_c.cc#L180