### PR TITLE
Building under MSVC and FindFFTW fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 # For OSX - don't clear RPATH on install
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-#locate mman.h include directory
-find_path(MMAN_INCLUDE_DIR sys/mman.h)
-
 if (WIN32)
     find_library (MMAN mman)
     if(NOT(MMAN))
@@ -21,11 +18,16 @@ if (WIN32)
     endif(NOT(MMAN))
 ENDIF (WIN32)
 
-#force std::complex<> typedefs in liquiddsp
-add_definitions(-D_LIBCPP_COMPLEX)
+if (MSVC)
+    find_path(MMAN_INCLUDE_DIR sys/mman.h)
 
-#enable math definitions in math.h
-add_definitions(-D_USE_MATH_DEFINES)
+    #force std::complex<> typedefs in liquiddsp
+    add_definitions(-D_LIBCPP_COMPLEX)
+
+    #enable math definitions in math.h
+    add_definitions(-D_USE_MATH_DEFINES)
+
+endif (MSVC)
 
 if (NOT CMAKE_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "-O2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 # For OSX - don't clear RPATH on install
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+#locate mman.h include directory
+find_path(MMAN_INCLUDE_DIR sys/mman.h)
+
 if (WIN32)
     find_library (MMAN mman)
     if(NOT(MMAN))
@@ -17,6 +20,12 @@ if (WIN32)
     set (extraLibs  ${extraLibs} ${MMAN})
     endif(NOT(MMAN))
 ENDIF (WIN32)
+
+#force std::complex<> typedefs in liquiddsp
+add_definitions(-D_LIBCPP_COMPLEX)
+
+#enable math definitions in math.h
+add_definitions(-D_USE_MATH_DEFINES)
 
 if (NOT CMAKE_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "-O2")
@@ -51,22 +60,16 @@ list(APPEND inspectrum_sources
     util.cpp
 )
 
-INCLUDE(FindPkgConfig)
-
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Concurrent REQUIRED)
-pkg_check_modules(FFTW REQUIRED fftw3f)
+find_package(FFTW REQUIRED)
 find_package(Liquid REQUIRED)
 
 include_directories(
+    ${MMAN_INCLUDE_DIR}
     ${QT_INCLUDES}
-    ${FFTW_INCLUDEDIR}
-    ${FFTW_INCLUDE_DIRS}
+    ${FFTW_INCLUDES}
     ${LIQUID_INCLUDES}
-)
-
-link_directories(
-    ${FFTW_LIBRARY_DIRS}
 )
 
 add_executable(inspectrum ${inspectrum_sources})

--- a/cmake/Modules/FindFFTW.cmake
+++ b/cmake/Modules/FindFFTW.cmake
@@ -10,9 +10,14 @@ if (FFTW_INCLUDES)
   set (FFTW_FIND_QUIETLY TRUE)
 endif (FFTW_INCLUDES)
 
-find_path (FFTW_INCLUDES fftw3.h)
+find_package(PkgConfig)
+pkg_check_modules(PC_FFTW QUIET fftw3f)
 
-find_library (FFTW_LIBRARIES NAMES fftw3)
+find_path (FFTW_INCLUDES fftw3.h
+    HINTS ${PC_FFTW_INCLUDEDIR}  ${PC_FFTW_INCLUDE_DIRS})
+
+find_library (FFTW_LIBRARIES NAMES fftw3f
+    HINTS ${PC_FFTW_LIBDIR} ${PC_FFTW_LIBRARY_DIRS})
 
 # handle the QUIETLY and REQUIRED arguments and set FFTW_FOUND to TRUE if
 # all listed variables are TRUE

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -26,7 +26,7 @@
 #include <QPixmapCache>
 #include <QRect>
 #include <liquid/liquid.h>
-
+#include <functional>
 #include <cstdlib>
 #include "util.h"
 


### PR DESCRIPTION
I'm trying to add inspectrum to PothosSDR installer: https://github.com/pothosware/PothosSDR/issues/41
I had to make some build changes listed below, I hope this is generally better. I also tested on gcc.

* added missing include for std::bind usage in spectrogramplot.cpp
* For MSVC: define _LIBCPP_COMPLEX to typedef std::complex in liquiddsp. Since std::complex is used for the liquid dsp sample type, this define tells liquid to use this typedef as opposed to the IQ struct.
* For MSVC: define _USE_MATH_DEFINES to enable M_PI and others. Although its also safe to define in general, even on non msvc platforms.
*  For MSVC: provide MMAN_INCLUDE_DIR in sys/mman.h. I needed a way to pass -DMMAN_INCLUDE_DIR to specify a custom path
* switch to find_package for FFTW. But added pkg-config support if that was needed, and fixed FFTW_LIBRARIES names to fftw3f. I suspect the library name issue was why this find script wasnt being used.
  * Anyway, the include(FindPkgConfig) was an issue, and the variables seem inconsistent. Using the find_package is preferable (and the find_package again for pkg config) in terms of cachable variables that can be passed in and optional pkg config.
  * Reference: https://cmake.org/Wiki/CMake:How_To_Find_Libraries

I hope this is helpful, let me know if I can clarify anything or test additional changes.