### PR TITLE
MSVC tweaks, large files, non-console usage, no mman dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,13 @@ if (MSVC)
 
     #enable math definitions in math.h
     add_definitions(-D_USE_MATH_DEFINES)
+
+    #build a graphical application without the console
+    option(BUILD_WIN32 "Build win32 app, false for console" TRUE)
+    if (BUILD_WIN32)
+        set(EXE_ARGS WIN32)
+        set(CMAKE_EXE_LINKER_FLAGS "/entry:mainCRTStartup ${CMAKE_EXE_LINKER_FLAGS}")
+    endif (BUILD_WIN32)
 endif (MSVC)
 
 if (NOT CMAKE_CXX_FLAGS)
@@ -61,7 +68,7 @@ include_directories(
     ${LIQUID_INCLUDES}
 )
 
-add_executable(inspectrum ${inspectrum_sources})
+add_executable(inspectrum ${EXE_ARGS} ${inspectrum_sources})
 qt5_use_modules(inspectrum Widgets Concurrent)
 
 target_link_libraries(inspectrum

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,24 +9,12 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 # For OSX - don't clear RPATH on install
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-if (WIN32)
-    find_library (MMAN mman)
-    if(NOT(MMAN))
-    message(FATAL_ERROR "please install mman-win32")
-    else(NOT(MMAN))
-    set (extraLibs  ${extraLibs} ${MMAN})
-    endif(NOT(MMAN))
-ENDIF (WIN32)
-
 if (MSVC)
-    find_path(MMAN_INCLUDE_DIR sys/mman.h)
-
     #force std::complex<> typedefs in liquiddsp
     add_definitions(-D_LIBCPP_COMPLEX)
 
     #enable math definitions in math.h
     add_definitions(-D_USE_MATH_DEFINES)
-
 endif (MSVC)
 
 if (NOT CMAKE_CXX_FLAGS)
@@ -68,7 +56,6 @@ find_package(FFTW REQUIRED)
 find_package(Liquid REQUIRED)
 
 include_directories(
-    ${MMAN_INCLUDE_DIR}
     ${QT_INCLUDES}
     ${FFTW_INCLUDES}
     ${LIQUID_INCLUDES}
@@ -81,7 +68,6 @@ target_link_libraries(inspectrum
     ${QT_LIBRARIES}
     ${FFTW_LIBRARIES}
     ${LIQUID_LIBRARIES}
-    ${extraLibs}
 )
 set(INSTALL_DEFAULT_BINDIR "bin" CACHE STRING "Appended to CMAKE_INSTALL_PREFIX")
 

--- a/amplitudedemod.cpp
+++ b/amplitudedemod.cpp
@@ -24,7 +24,7 @@ AmplitudeDemod::AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>
 
 }
 
-void AmplitudeDemod::work(void *input, void *output, int count, off_t sampleid)
+void AmplitudeDemod::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);

--- a/amplitudedemod.h
+++ b/amplitudedemod.h
@@ -25,5 +25,5 @@ class AmplitudeDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
     AmplitudeDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
-    void work(void *input, void *output, int count, off_t sampleid) override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
 };

--- a/cursors.cpp
+++ b/cursors.cpp
@@ -92,7 +92,7 @@ bool Cursors::mouseEvent(QEvent::Type type, QMouseEvent event)
     return false;
 }
 
-void Cursors::paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void Cursors::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     painter.save();
 

--- a/cursors.h
+++ b/cursors.h
@@ -34,7 +34,7 @@ public:
     Cursors(QObject * parent);
     int segments();
     bool mouseEvent(QEvent::Type type, QMouseEvent event);
-    void paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
+    void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     range_t<int> selection();
     void setSegments(int segments);
     void setSelection(range_t<int> selection);

--- a/frequencydemod.cpp
+++ b/frequencydemod.cpp
@@ -26,7 +26,7 @@ FrequencyDemod::FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>
 
 }
 
-void FrequencyDemod::work(void *input, void *output, int count, off_t sampleid)
+void FrequencyDemod::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);

--- a/frequencydemod.h
+++ b/frequencydemod.h
@@ -25,5 +25,5 @@ class FrequencyDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
     FrequencyDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
-    void work(void *input, void *output, int count, off_t sampleid) override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
 };

--- a/inputsource.cpp
+++ b/inputsource.cpp
@@ -35,7 +35,7 @@ public:
         return sizeof(std::complex<float>);
     }
 
-    void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) override {
+    void copyRange(const void* const src, size_t start, size_t length, std::complex<float>* const dest) override {
         auto s = reinterpret_cast<const std::complex<float>*>(src);
         std::copy(&s[start], &s[start + length], dest);
     }
@@ -47,7 +47,7 @@ public:
         return sizeof(std::complex<int16_t>);
     }
 
-    void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) override {
+    void copyRange(const void* const src, size_t start, size_t length, std::complex<float>* const dest) override {
         auto s = reinterpret_cast<const std::complex<int16_t>*>(src);
         std::transform(&s[start], &s[start + length], dest,
             [](const std::complex<int16_t>& v) -> std::complex<float> {
@@ -64,7 +64,7 @@ public:
         return sizeof(std::complex<int8_t>);
     }
     
-    void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) override {
+    void copyRange(const void* const src, size_t start, size_t length, std::complex<float>* const dest) override {
         auto s = reinterpret_cast<const std::complex<int8_t>*>(src);
         std::transform(&s[start], &s[start + length], dest,
             [](const std::complex<int8_t>& v) -> std::complex<float> {
@@ -81,7 +81,7 @@ public:
         return sizeof(std::complex<uint8_t>);
     }
     
-    void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) override {
+    void copyRange(const void* const src, size_t start, size_t length, std::complex<float>* const dest) override {
         auto s = reinterpret_cast<const std::complex<uint8_t>*>(src);
         std::transform(&s[start], &s[start + length], dest,
             [](const std::complex<uint8_t>& v) -> std::complex<float> {
@@ -154,18 +154,18 @@ void InputSource::openFile(const char *filename)
     invalidate();
 }
 
-void InputSource::setSampleRate(off_t rate)
+void InputSource::setSampleRate(size_t rate)
 {
     sampleRate = rate;
     invalidate();
 }
 
-off_t InputSource::rate()
+size_t InputSource::rate()
 {
     return sampleRate;
 }
 
-std::unique_ptr<std::complex<float>[]> InputSource::getSamples(off_t start, off_t length)
+std::unique_ptr<std::complex<float>[]> InputSource::getSamples(size_t start, size_t length)
 {
     if (inputFile == nullptr)
         return nullptr;

--- a/inputsource.h
+++ b/inputsource.h
@@ -27,15 +27,15 @@
 class SampleAdapter {
 public:
     virtual size_t sampleSize() = 0;
-    virtual void copyRange(const void* const src, off_t start, off_t length, std::complex<float>* const dest) = 0;
+    virtual void copyRange(const void* const src, size_t start, size_t length, std::complex<float>* const dest) = 0;
 };
 
 class InputSource : public SampleSource<std::complex<float>>
 {
 private:
     QFile *inputFile = nullptr;
-    off_t sampleCount = 0;
-    off_t sampleRate = 0;
+    size_t sampleCount = 0;
+    size_t sampleRate = 0;
     uchar *mmapData = nullptr;
     std::unique_ptr<SampleAdapter> sampleAdapter;
 
@@ -44,12 +44,12 @@ public:
     ~InputSource();
     void cleanup();
     void openFile(const char *filename);
-    std::unique_ptr<std::complex<float>[]> getSamples(off_t start, off_t length);
-    off_t count() {
+    std::unique_ptr<std::complex<float>[]> getSamples(size_t start, size_t length);
+    size_t count() {
         return sampleCount;
     };
-    void setSampleRate(off_t rate);
-    off_t rate();
+    void setSampleRate(size_t rate);
+    size_t rate();
     float relativeBandwidth() {
         return 1;
     }

--- a/inputsource.h
+++ b/inputsource.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <complex>
+#include <QFile>
 #include "samplesource.h"
 
 class SampleAdapter {
@@ -32,11 +33,10 @@ public:
 class InputSource : public SampleSource<std::complex<float>>
 {
 private:
-    FILE *inputFile = nullptr;
-    off_t fileSize = 0;
+    QFile *inputFile = nullptr;
     off_t sampleCount = 0;
     off_t sampleRate = 0;
-    void *mmapData = nullptr;
+    uchar *mmapData = nullptr;
     std::unique_ptr<SampleAdapter> sampleAdapter;
 
 public:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -17,6 +17,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QMessageBox>
 #include <QtWidgets>
 #include <QPixmapCache>
 #include <QRubberBand>
@@ -84,7 +85,15 @@ void MainWindow::openFile(QString fileName)
         }
     }
 
-    input->openFile(fileName.toUtf8().constData());
+    try
+    {
+        input->openFile(fileName.toUtf8().constData());
+    }
+    catch (const std::exception &ex)
+    {
+        QMessageBox msgBox(QMessageBox::Critical, "Inspectrum openFile error", QString("%1: %2").arg(fileName).arg(ex.what()));
+        msgBox.exec();
+    }
 }
 
 void MainWindow::setSampleRate(QString rate)

--- a/phasedemod.cpp
+++ b/phasedemod.cpp
@@ -24,7 +24,7 @@ PhaseDemod::PhaseDemod(std::shared_ptr<SampleSource<std::complex<float>>> src) :
 
 }
 
-void PhaseDemod::work(void *input, void *output, int count, off_t sampleid)
+void PhaseDemod::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in = static_cast<std::complex<float>*>(input);
     auto out = static_cast<float*>(output);

--- a/phasedemod.h
+++ b/phasedemod.h
@@ -25,5 +25,5 @@ class PhaseDemod : public SampleBuffer<std::complex<float>, float>
 {
 public:
     PhaseDemod(std::shared_ptr<SampleSource<std::complex<float>>> src);
-    void work(void *input, void *output, int count, off_t sampleid) override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
 };

--- a/plot.cpp
+++ b/plot.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<AbstractSampleSource> Plot::output()
 	return sampleSource;
 }
 
-void Plot::paintBack(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void Plot::paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     painter.save();
     QPen pen(Qt::white, 1, Qt::DashLine);
@@ -53,12 +53,12 @@ void Plot::paintBack(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
     painter.restore();
 }
 
-void Plot::paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void Plot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
 
 }
 
-void Plot::paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void Plot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
 
 }

--- a/plot.h
+++ b/plot.h
@@ -35,9 +35,9 @@ public:
     void invalidateEvent() override;
     virtual bool mouseEvent(QEvent::Type type, QMouseEvent event);
     virtual std::shared_ptr<AbstractSampleSource> output();
-    virtual void paintBack(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
-    virtual void paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
-    virtual void paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
+    virtual void paintBack(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
+    virtual void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
+    virtual void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     int height() const { return _height; };
 
 signals:

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -150,7 +150,7 @@ void PlotView::cursorsMoved()
 
 void PlotView::emitTimeSelection()
 {
-    off_t sampleCount = selectedSamples.length();
+    size_t sampleCount = selectedSamples.length();
     float selectionTime = sampleCount / (float)mainSampleSource->rate();
     emit timeSelectionChanged(selectionTime);
 }
@@ -306,7 +306,7 @@ void PlotView::exportSamples(std::shared_ptr<AbstractSampleSource> src)
     if (dialog.exec()) {
         QStringList fileNames = dialog.selectedFiles();
        
-        off_t start, end;
+        size_t start, end;
         if (cursorSelection.isChecked()) {
             start = selectedSamples.minimum;
             end = start + selectedSamples.length();
@@ -320,12 +320,12 @@ void PlotView::exportSamples(std::shared_ptr<AbstractSampleSource> src)
 
         std::ofstream os (fileNames[0].toStdString(), std::ios::binary);
 
-        off_t index;
+        size_t index;
         // viewRange.length() is used as some less arbitrary step value
-        off_t step = viewRange.length();
+        size_t step = viewRange.length();
 
         for (index = start; index < end; index += step) {
-            off_t length = std::min(step, end - index); 
+            size_t length = std::min(step, end - index); 
             auto samples = sampleSrc->getSamples(index, length);
             if (samples != nullptr) {
                 for (auto i = 0; i < length; i += decimation.value()) {
@@ -428,7 +428,7 @@ void PlotView::paintEvent(QPaintEvent *event)
 #undef PLOT_LAYER
 }
 
-void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     float startTime = (float)sampleRange.minimum / sampleRate;
     float stopTime = (float)sampleRange.maximum / sampleRate;
@@ -454,7 +454,7 @@ void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<off_t> sam
 
     while (tick <= stopTime) {
 
-        off_t tickSample = tick * sampleRate;
+        size_t tickSample = tick * sampleRate;
         int tickLine = sampleToColumn(tickSample - sampleRange.minimum);
 
         char buf[128];
@@ -471,7 +471,7 @@ void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<off_t> sam
     tick = firstTick;
     while (tick <= stopTime) {
 
-        off_t tickSample = tick * sampleRate;
+        size_t tickSample = tick * sampleRate;
         int tickLine = sampleToColumn(tickSample - sampleRange.minimum);
 
         painter.drawLine(tickLine, 0, tickLine, 10);
@@ -495,7 +495,7 @@ void PlotView::resizeEvent(QResizeEvent * event)
     updateView();
 }
 
-off_t PlotView::samplesPerColumn()
+size_t PlotView::samplesPerColumn()
 {
     return fftSize / zoomLevel;
 }
@@ -538,7 +538,7 @@ void PlotView::updateView(bool reCenter)
     viewport()->update();
 }
 
-void PlotView::setSampleRate(off_t rate)
+void PlotView::setSampleRate(size_t rate)
 {
     sampleRate = rate;
 
@@ -558,12 +558,12 @@ void PlotView::enableScales(bool enabled)
     viewport()->update();
 }
 
-int PlotView::sampleToColumn(off_t sample)
+int PlotView::sampleToColumn(size_t sample)
 {
     return sample / samplesPerColumn();
 }
 
-off_t PlotView::columnToSample(int col)
+size_t PlotView::columnToSample(int col)
 {
     return col * samplesPerColumn();
 }

--- a/plotview.h
+++ b/plotview.h
@@ -35,7 +35,7 @@ class PlotView : public QGraphicsView, Subscriber
 
 public:
     PlotView(InputSource *input);
-    void setSampleRate(off_t rate);
+    void setSampleRate(size_t rate);
 
 signals:
     void timeSelectionChanged(float time);
@@ -65,17 +65,17 @@ private:
     SampleSource<std::complex<float>> *mainSampleSource = nullptr;
     SpectrogramPlot *spectrogramPlot = nullptr;
     std::vector<std::unique_ptr<Plot>> plots;
-    range_t<off_t> viewRange;
-    range_t<off_t> selectedSamples;
+    range_t<size_t> viewRange;
+    range_t<size_t> selectedSamples;
     int zoomPos;
-    off_t zoomSample;
+    size_t zoomSample;
 
     int fftSize = 1024;
     int zoomLevel = 0;
     int powerMin;
     int powerMax;
     bool cursorsEnabled;
-    off_t sampleRate = 0;
+    size_t sampleRate = 0;
     bool timeScaleEnabled;
     int scrollZoomStepsAccumulated = 0;
 
@@ -85,11 +85,11 @@ private:
     void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     template<typename SOURCETYPE> void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     int plotsHeight();
-    off_t samplesPerColumn();
+    size_t samplesPerColumn();
     void updateViewRange(bool reCenter);
     void updateView(bool reCenter = false);
-    void paintTimeScale(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
+    void paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
 
-    int sampleToColumn(off_t sample);
-    off_t columnToSample(int col);
+    int sampleToColumn(size_t sample);
+    size_t columnToSample(int col);
 };

--- a/samplebuffer.cpp
+++ b/samplebuffer.cpp
@@ -34,10 +34,10 @@ SampleBuffer<Tin, Tout>::~SampleBuffer()
 }
 
 template <typename Tin, typename Tout>
-std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(off_t start, off_t length)
+std::unique_ptr<Tout[]> SampleBuffer<Tin, Tout>::getSamples(size_t start, size_t length)
 {
     // TODO: base this on the actual history required
-    auto history = std::min(start, (off_t)256);
+    auto history = std::min(start, (size_t)256);
     auto samples = src->getSamples(start - history, length + history);
     if (samples == nullptr)
     	return nullptr;

--- a/samplebuffer.h
+++ b/samplebuffer.h
@@ -35,12 +35,12 @@ public:
     SampleBuffer(std::shared_ptr<SampleSource<Tin>> src);
     ~SampleBuffer();
     void invalidateEvent();
-    virtual std::unique_ptr<Tout[]> getSamples(off_t start, off_t length);
-    virtual void work(void *input, void *output, int count, off_t sampleid) = 0;
-    virtual off_t count() {
+    virtual std::unique_ptr<Tout[]> getSamples(size_t start, size_t length);
+    virtual void work(void *input, void *output, int count, size_t sampleid) = 0;
+    virtual size_t count() {
         return src->count();
     };
-    off_t rate() {
+    size_t rate() {
         return src->rate();
     };
 

--- a/samplesource.h
+++ b/samplesource.h
@@ -30,10 +30,10 @@ class SampleSource : public AbstractSampleSource
 public:
     virtual ~SampleSource() {};
 
-    virtual std::unique_ptr<T[]> getSamples(off_t start, off_t length) = 0;
+    virtual std::unique_ptr<T[]> getSamples(size_t start, size_t length) = 0;
     virtual void invalidateEvent() { };
-    virtual off_t count() = 0;
-    virtual off_t rate() = 0;
+    virtual size_t count() = 0;
+    virtual size_t rate() = 0;
     virtual float relativeBandwidth() = 0;
     std::type_index sampleType() override;
 };

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -56,7 +56,7 @@ void SpectrogramPlot::invalidateEvent()
     emit repaint();
 }
 
-void SpectrogramPlot::paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void SpectrogramPlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     if (tunerEnabled())
         tuner.paintFront(painter, rect, sampleRange);
@@ -137,13 +137,13 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
     painter.restore();
 }
 
-void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     if (!inputSource || inputSource->count() == 0)
         return;
 
-    off_t sampleOffset = sampleRange.minimum % (getStride() * linesPerTile());
-    off_t tileID = sampleRange.minimum - sampleOffset;
+    size_t sampleOffset = sampleRange.minimum % (getStride() * linesPerTile());
+    size_t tileID = sampleRange.minimum - sampleOffset;
     int xoffset = sampleOffset / getStride();
 
     // Paint first (possibly partial) tile
@@ -159,7 +159,7 @@ void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<off_t> sa
     }
 }
 
-QPixmap* SpectrogramPlot::getPixmapTile(off_t tile)
+QPixmap* SpectrogramPlot::getPixmapTile(size_t tile)
 {
     QPixmap *obj = pixmapCache.object(TileCacheKey(fftSize, zoomLevel, tile));
     if (obj != 0)
@@ -184,7 +184,7 @@ QPixmap* SpectrogramPlot::getPixmapTile(off_t tile)
     return obj;
 }
 
-float* SpectrogramPlot::getFFTTile(off_t tile)
+float* SpectrogramPlot::getFFTTile(size_t tile)
 {
     std::array<float, tileSize>* obj = fftCache.object(TileCacheKey(fftSize, zoomLevel, tile));
     if (obj != nullptr)
@@ -192,7 +192,7 @@ float* SpectrogramPlot::getFFTTile(off_t tile)
 
     std::array<float, tileSize>* destStorage = new std::array<float, tileSize>;
     float *ptr = destStorage->data();
-    off_t sample = tile;
+    size_t sample = tile;
     while ((ptr - destStorage->data()) < tileSize) {
         getLine(ptr, sample);
         sample += getStride();
@@ -202,7 +202,7 @@ float* SpectrogramPlot::getFFTTile(off_t tile)
     return destStorage->data();
 }
 
-void SpectrogramPlot::getLine(float *dest, off_t sample)
+void SpectrogramPlot::getLine(float *dest, size_t sample)
 {
     if (inputSource && fft) {
         auto buffer = inputSource->getSamples(sample, fftSize);
@@ -312,7 +312,7 @@ void SpectrogramPlot::setZoomLevel(int zoom)
     zoomLevel = zoom;
 }
 
-void SpectrogramPlot::setSampleRate(off_t rate)
+void SpectrogramPlot::setSampleRate(size_t rate)
 {
     sampleRate = rate;
 }

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -41,11 +41,11 @@ public:
     SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src);
     void invalidateEvent() override;
     std::shared_ptr<AbstractSampleSource> output() override;
-    void paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange) override;
-    void paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange) override;
+    void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
+    void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
     bool mouseEvent(QEvent::Type type, QMouseEvent event) override;
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
-    void setSampleRate(off_t sampleRate);
+    void setSampleRate(size_t sampleRate);
     bool tunerEnabled();
     void enableScales(bool enabled);
 
@@ -71,15 +71,15 @@ private:
     int zoomLevel;
     float powerMax;
     float powerMin;
-    off_t sampleRate;
+    size_t sampleRate;
     bool frequencyScaleEnabled;
 
     Tuner tuner;
     std::shared_ptr<TunerTransform> tunerTransform;
 
-    QPixmap* getPixmapTile(off_t tile);
-    float* getFFTTile(off_t tile);
-    void getLine(float *dest, off_t sample);
+    QPixmap* getPixmapTile(size_t tile);
+    float* getFFTTile(size_t tile);
+    void getLine(float *dest, size_t sample);
     int getStride();
     float getTunerPhaseInc();
     std::vector<float> getTunerTaps();
@@ -91,7 +91,7 @@ class TileCacheKey
 {
 
 public:
-    TileCacheKey(int fftSize, int zoomLevel, off_t sample) {
+    TileCacheKey(int fftSize, int zoomLevel, size_t sample) {
         this->fftSize = fftSize;
         this->zoomLevel = zoomLevel;
         this->sample = sample;
@@ -105,5 +105,5 @@ public:
 
     int fftSize;
     int zoomLevel;
-    off_t sample;
+    size_t sample;
 };

--- a/threshold.cpp
+++ b/threshold.cpp
@@ -24,7 +24,7 @@ Threshold::Threshold(std::shared_ptr<SampleSource<float>> src) : SampleBuffer(sr
 
 }
 
-void Threshold::work(void *input, void *output, int count, off_t sampleid)
+void Threshold::work(void *input, void *output, int count, size_t sampleid)
 {
     auto in = static_cast<float*>(input);
     auto out = static_cast<float*>(output);

--- a/threshold.h
+++ b/threshold.h
@@ -25,5 +25,5 @@ class Threshold : public SampleBuffer<float, float>
 {
 public:
     Threshold(std::shared_ptr<SampleSource<float>> src);
-    void work(void *input, void *output, int count, off_t sampleid) override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
 };

--- a/traceplot.cpp
+++ b/traceplot.cpp
@@ -27,12 +27,12 @@ TracePlot::TracePlot(std::shared_ptr<AbstractSampleSource> source) : Plot(source
     connect(this, &TracePlot::imageReady, this, &TracePlot::handleImage);
 }
 
-void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     int samplesPerColumn = sampleRange.length() / rect.width();
     int samplesPerTile = tileWidth * samplesPerColumn;
-    off_t tileID = sampleRange.minimum / samplesPerTile;
-    off_t tileOffset = sampleRange.minimum % samplesPerTile; // Number of samples to skip from first image tile
+    size_t tileID = sampleRange.minimum / samplesPerTile;
+    size_t tileOffset = sampleRange.minimum % samplesPerTile; // Number of samples to skip from first image tile
     int xOffset = tileOffset / samplesPerColumn; // Number of columns to skip from first image tile
 
     // Paint first (possibly partial) tile
@@ -51,7 +51,7 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRa
     }
 }
 
-QPixmap TracePlot::getTile(off_t tileID, off_t sampleCount)
+QPixmap TracePlot::getTile(size_t tileID, size_t sampleCount)
 {
     QPixmap pixmap(tileWidth, height());
     QString key;
@@ -60,7 +60,7 @@ QPixmap TracePlot::getTile(off_t tileID, off_t sampleCount)
         return pixmap;
 
     if (!tasks.contains(key)) {
-        range_t<off_t> sampleRange{tileID * sampleCount, (tileID + 1) * sampleCount};
+        range_t<size_t> sampleRange{tileID * sampleCount, (tileID + 1) * sampleCount};
         QtConcurrent::run(this, &TracePlot::drawTile, key, QRect(0, 0, tileWidth, height()), sampleRange);
         tasks.insert(key);
     }
@@ -68,7 +68,7 @@ QPixmap TracePlot::getTile(off_t tileID, off_t sampleCount)
     return pixmap;
 }
 
-void TracePlot::drawTile(QString key, const QRect &rect, range_t<off_t> sampleRange)
+void TracePlot::drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange)
 {
     QImage image(rect.size(), QImage::Format_ARGB32);
     image.fill(Qt::transparent);
@@ -113,13 +113,13 @@ void TracePlot::handleImage(QString key, QImage image)
     emit repaint();
 }
 
-void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples, off_t count, int step = 1)
+void TracePlot::plotTrace(QPainter &painter, const QRect &rect, float *samples, size_t count, int step = 1)
 {
     QPainterPath path;
     range_t<float> xRange{0, rect.width() - 2.f};
     range_t<float> yRange{0, rect.height() - 2.f};
     const float xStep = 1.0 / count * rect.width();
-    for (off_t i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         float sample = samples[i*step];
         float x = i * xStep;
         float y = (1 - sample) * (rect.height() / 2);

--- a/traceplot.h
+++ b/traceplot.h
@@ -30,7 +30,7 @@ class TracePlot : public Plot
 public:
 	TracePlot(std::shared_ptr<AbstractSampleSource> source);
 
-    void paintMid(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
+    void paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     std::shared_ptr<AbstractSampleSource> source() { return sampleSource; };
 
 signals:
@@ -43,7 +43,7 @@ private:
 	QSet<QString> tasks;
 	const int tileWidth = 1000;
 
-	QPixmap getTile(off_t tileID, off_t sampleCount);
-	void drawTile(QString key, const QRect &rect, range_t<off_t> sampleRange);
-	void plotTrace(QPainter &painter, const QRect &rect, float *samples, off_t count, int step);
+	QPixmap getTile(size_t tileID, size_t sampleCount);
+	void drawTile(QString key, const QRect &rect, range_t<size_t> sampleRange);
+	void plotTrace(QPainter &painter, const QRect &rect, float *samples, size_t count, int step);
 };

--- a/tuner.cpp
+++ b/tuner.cpp
@@ -75,7 +75,7 @@ bool Tuner::mouseEvent(QEvent::Type type, QMouseEvent event)
     return false;
 }
 
-void Tuner::paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange)
+void Tuner::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     painter.save();
 

--- a/tuner.h
+++ b/tuner.h
@@ -35,7 +35,7 @@ public:
     int centre();
     int deviation();
     bool mouseEvent(QEvent::Type, QMouseEvent event);
-    void paintFront(QPainter &painter, QRect &rect, range_t<off_t> sampleRange);
+    void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
     void setCentre(int centre);
     void setDeviation(int dev);
     void setHeight(int height);

--- a/tunertransform.cpp
+++ b/tunertransform.cpp
@@ -26,7 +26,7 @@ TunerTransform::TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>
 
 }
 
-void TunerTransform::work(void *input, void *output, int count, off_t sampleid)
+void TunerTransform::work(void *input, void *output, int count, size_t sampleid)
 {
     auto out = static_cast<std::complex<float>*>(output);
     std::unique_ptr<std::complex<float>[]> temp(new std::complex<float>[count]);

--- a/tunertransform.h
+++ b/tunertransform.h
@@ -31,7 +31,7 @@ private:
 
 public:
     TunerTransform(std::shared_ptr<SampleSource<std::complex<float>>> src);
-    void work(void *input, void *output, int count, off_t sampleid) override;
+    void work(void *input, void *output, int count, size_t sampleid) override;
     void setFrequency(float frequency);
     void setTaps(std::vector<float> taps);
     void setRelativeBandwith(float bandwidth);


### PR DESCRIPTION
I was getting ready to build an installer with inspectrum. Here are the final two issues that I had to address:

1) support launching from a shortcut without the cmd console also appearing
  * Graphical win32 app is the default, but console mode can be enabled with BUILD_WIN32=OFF
  * Handle uncaught exceptions when file open fails with modal dialog box to display error

2) supporting large files. I fixed an issue opening a file which was just over the signed 32-bit boundary. Some of the stat stuff and off_t were typedef for a signed 32 bit integer. This is probably the result of being an LLP64 style system. But to address this:
  * Used Qt's file utilities to handle file size and file mapping. This removed the need for the mman dependencies entirely
  * Replaced off_t with size_t (using sed). I know this feels invasive, but size_t matches the system's memory size, which is why stl widely uses it. So I think size_t is the better answer in general for buffer sizes and buffer offsets. It also fixes my typedef size issue mentioned above.
    * Further the off_t was really only used with file io functions, which is replaced by qt routines which use 64-bit numbers as well. See https://stackoverflow.com/questions/10634629/what-are-the-usage-differences-between-size-t-and-off-t
   * I should note that off_t is signed and size_t is not. I didn’t see any uses of off_t numbers needing signed-ness, but that’s something to consider.

Let me know if I can clarify, make changes, split up commits etc.