### PR TITLE
Tighten transition band when tuner bandwidth is narrow

### DIFF
--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -249,7 +249,7 @@ std::vector<float> SpectrogramPlot::getTunerTaps()
     float cutoff = tuner.deviation() / (float)fftSize;
     float gain = pow(10.0f, powerMax / -10.0f);
     auto atten = 60.0f;
-    auto len = estimate_req_filter_len(0.05f, atten);
+    auto len = estimate_req_filter_len(std::min(cutoff, 0.05f), atten);
     auto taps = std::vector<float>(len);
     liquid_firdes_kaiser(len, cutoff, atten, 0.0f, taps.data());
     std::transform(taps.begin(), taps.end(), taps.begin(),


### PR DESCRIPTION
Let's say, hypothetically speaking, you wanted to use the derived frequency plot on one of the 300 baud carriers of a V.21 modem connection captured at 44100 samples per second. The channel bandwidth is very narrow compared to the sample rate, so the adjacent channel interferes with demodulation due to the fixed transition bandwidth of the tuner filter. This patch makes the transition bandwidth equal to the cutoff frequency when the tuner bandwidth is narrow and leaves things unchanged when the tuner bandwidth is wide.