### PR TITLE
Adds Frequency Offset option to adjust the vertical freq to captured frequency center

### DIFF
--- a/inputsource.cpp
+++ b/inputsource.cpp
@@ -249,6 +249,17 @@ double InputSource::rate()
     return sampleRate;
 }
 
+void InputSource::setFrequencyOffset(double offset)
+{
+    frequencyOffset = offset;
+    invalidate();
+}
+
+double InputSource::offset()
+{
+    return frequencyOffset;
+}
+
 std::unique_ptr<std::complex<float>[]> InputSource::getSamples(size_t start, size_t length)
 {
     if (inputFile == nullptr)

--- a/inputsource.h
+++ b/inputsource.h
@@ -36,6 +36,7 @@ private:
     QFile *inputFile = nullptr;
     size_t sampleCount = 0;
     double sampleRate = 0.0;
+    double frequencyOffset = 0.0;
     uchar *mmapData = nullptr;
     std::unique_ptr<SampleAdapter> sampleAdapter;
     std::string _fmt;
@@ -51,8 +52,10 @@ public:
         return sampleCount;
     };
     void setSampleRate(double rate);
+    void setFrequencyOffset(double rate);
     void setFormat(std::string fmt);
     double rate();
+    double offset();
     bool realSignal() {
         return _realSignal;
     };

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -44,6 +44,7 @@ MainWindow::MainWindow()
     // Connect dock inputs
     connect(dock, &SpectrogramControls::openFile, this, &MainWindow::openFile);
     connect(dock->sampleRate, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textChanged), this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::setSampleRate));
+    connect(dock->frequencyOffset, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textChanged), this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::setFrequencyOffset));
     connect(dock, static_cast<void (SpectrogramControls::*)(int, int)>(&SpectrogramControls::fftOrZoomChanged), plots, &PlotView::setFFTAndZoom);
     connect(dock->powerMaxSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMax);
     connect(dock->powerMinSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMin);
@@ -107,9 +108,25 @@ void MainWindow::setSampleRate(QString rate)
     settings.setValue("SampleRate", sampleRate);
 }
 
+void MainWindow::setFrequencyOffset(QString rate)
+{
+    auto frequencyOffset = rate.toDouble();
+    input->setFrequencyOffset(frequencyOffset);
+    plots->setFrequencyOffset(frequencyOffset);
+
+    // Save the frequency offset in settings as we're likely to be opening the same file across multiple runs
+    QSettings settings;
+    settings.setValue("FrequencyOffset", frequencyOffset);
+}
+
 void MainWindow::setSampleRate(double rate)
 {
     dock->sampleRate->setText(QString::number(rate));
+}
+
+void MainWindow::setFrequencyOffset(double rate)
+{
+    dock->frequencyOffset->setText(QString::number(rate));
 }
 
 void MainWindow::setFormat(QString fmt)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,6 +36,8 @@ public slots:
     void openFile(QString fileName);
     void setSampleRate(QString rate);
     void setSampleRate(double rate);
+    void setFrequencyOffset(QString rate);
+    void setFrequencyOffset(double rate);
     void setFormat(QString fmt);
 
 private:

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -505,6 +505,7 @@ void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sa
 
     painter.restore();
 }
+
 int PlotView::plotsHeight()
 {
     int height = 0;

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -505,7 +505,6 @@ void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sa
 
     painter.restore();
 }
-
 int PlotView::plotsHeight()
 {
     int height = 0;
@@ -569,6 +568,16 @@ void PlotView::setSampleRate(double rate)
 
     if (spectrogramPlot != nullptr)
         spectrogramPlot->setSampleRate(rate);
+
+    emitTimeSelection();
+}
+
+void PlotView::setFrequencyOffset(double rate)
+{
+    frequencyOffset = rate;
+
+    if (spectrogramPlot != nullptr)
+        spectrogramPlot->setFrequencyOffset(rate);
 
     emitTimeSelection();
 }

--- a/plotview.h
+++ b/plotview.h
@@ -36,6 +36,7 @@ class PlotView : public QGraphicsView, Subscriber
 public:
     PlotView(InputSource *input);
     void setSampleRate(double rate);
+    void setFrequencyOffset(double rate);
 
 signals:
     void timeSelectionChanged(float time);
@@ -76,6 +77,7 @@ private:
     int powerMax;
     bool cursorsEnabled;
     double sampleRate = 0.0;
+    double frequencyOffset = 0.0;
     bool timeScaleEnabled;
     int scrollZoomStepsAccumulated = 0;
 

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -41,6 +41,12 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     sampleRate->setValidator(double_validator);
     layout->addRow(new QLabel(tr("Sample rate:")), sampleRate);
 
+    frequencyOffset = new QLineEdit();
+    auto freq_validator = new QDoubleValidator(this);
+    freq_validator->setBottom(0.0);
+    frequencyOffset->setValidator(freq_validator);
+    layout->addRow(new QLabel(tr("Frequency offset:")), frequencyOffset);
+
     // Spectrogram settings
     layout->addRow(new QLabel()); // TODO: find a better way to add an empty row?
     layout->addRow(new QLabel(tr("<b>Spectrogram</b>")));
@@ -130,6 +136,10 @@ void SpectrogramControls::setDefaults()
     QSettings settings;
     int savedSampleRate = settings.value("SampleRate", 8000000).toInt();
     sampleRate->setText(QString::number(savedSampleRate));
+
+    int savedFrequencyOffset = settings.value("FrequencyOffset", 0).toInt();
+    frequencyOffset->setText(QString::number(savedFrequencyOffset));
+
     fftSizeSlider->setValue(settings.value("FFTSize", 9).toInt());
     powerMaxSlider->setValue(settings.value("PowerMax", 0).toInt());
     powerMinSlider->setValue(settings.value("PowerMin", -100).toInt());

--- a/spectrogramcontrols.h
+++ b/spectrogramcontrols.h
@@ -62,6 +62,7 @@ private:
 public:
     QPushButton *fileOpenButton;
     QLineEdit *sampleRate;
+    QLineEdit *frequencyOffset;
     QSlider *fftSizeSlider;
     QSlider *zoomLevelSlider;
     QSlider *powerMaxSlider;

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -104,22 +104,6 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
             painter.drawLine(0, tickny, 30, tickny); // draws neg lines
         painter.drawLine(0, tickpy, 30, tickpy); // draws pos lines
 
-        if (tick == 0) {
-            char buf[128];
-
-            if (bwPerTick % 1000000000 == 0) {
-                snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000000);
-            } else if (bwPerTick % 1000000 == 0) {
-                snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000);
-            } else if(bwPerTick % 1000 == 0) {
-                snprintf(buf, sizeof(buf), "%d kHz", ((int)frequencyOffset + (int)tick) / 1000);
-            } else {
-                snprintf(buf, sizeof(buf), "%d Hz", (int)frequencyOffset + tick);
-            }
-
-            painter.drawText(0, tickpy+5, buf);  // draw 0
-        }
-
         if (tick != 0) {
             char buf[128];
 
@@ -152,22 +136,21 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
     }
 
     // Draw small ticks
-//    bwPerTick /= 10;
-//
-//    if (bwPerTick >= 1 ) {
-//        tick = 0;
-//        while (tick <= sampleRate / 2) {
-//
-//            int tickpy = plotHeight / 2 - tick / bwPerPixel + y;
-//            int tickny = plotHeight / 2 + tick / bwPerPixel + y;
-//
-//            if (!inputSource->realSignal())
-//                painter.drawLine(0, tickny, 3, tickny);
-//            painter.drawLine(0, tickpy, 3, tickpy);
-//
-//            tick += bwPerTick;
-//        }
-//    }
+    bwPerTick /= 10;
+    if (bwPerTick >= 1 ) {
+        tick = 0;
+        while (tick <= sampleRate / 2) {
+
+            int tickpy = plotHeight / 2 - tick / bwPerPixel + y;
+            int tickny = plotHeight / 2 + tick / bwPerPixel + y;
+
+            if (!inputSource->realSignal())
+                painter.drawLine(0, tickny, 3, tickny);
+            painter.drawLine(0, tickpy, 3, tickpy);
+
+            tick += bwPerTick;
+        }
+    }
     painter.restore();
 }
 

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -101,47 +101,73 @@ void SpectrogramPlot::paintFrequencyScale(QPainter &painter, QRect &rect)
         int tickny = plotHeight / 2 + tick / bwPerPixel + y;
 
         if (!inputSource->realSignal())
-            painter.drawLine(0, tickny, 30, tickny);
-        painter.drawLine(0, tickpy, 30, tickpy);
+            painter.drawLine(0, tickny, 30, tickny); // draws neg lines
+        painter.drawLine(0, tickpy, 30, tickpy); // draws pos lines
+
+        if (tick == 0) {
+            char buf[128];
+
+            if (bwPerTick % 1000000000 == 0) {
+                snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000000);
+            } else if (bwPerTick % 1000000 == 0) {
+                snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000);
+            } else if(bwPerTick % 1000 == 0) {
+                snprintf(buf, sizeof(buf), "%d kHz", ((int)frequencyOffset + (int)tick) / 1000);
+            } else {
+                snprintf(buf, sizeof(buf), "%d Hz", (int)frequencyOffset + tick);
+            }
+
+            painter.drawText(0, tickpy+5, buf);  // draw 0
+        }
 
         if (tick != 0) {
             char buf[128];
 
-            if (bwPerTick % 1000000 == 0) {
-                snprintf(buf, sizeof(buf), "-%d MHz", (int)tick / 1000000);
-            } else if(bwPerTick % 1000 == 0) {
-                snprintf(buf, sizeof(buf), "-%d kHz", tick / 1000);
-            } else {
-                snprintf(buf, sizeof(buf), "-%d Hz", tick);
+            if (!inputSource->realSignal()) {
+                if (bwPerTick % 1000000000 == 0) {
+                  snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset - (int)tick) / 1000000000);
+                } else if (bwPerTick % 1000000 == 0) {
+                  snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset - (int)tick) / 1000000);
+                } else if(bwPerTick % 1000 == 0) {
+                  snprintf(buf, sizeof(buf), "%d kHz", ((int)frequencyOffset - (int)tick) / 1000);
+                } else {
+                  snprintf(buf, sizeof(buf), "%d Hz", (int)frequencyOffset - tick);
+                }
+              painter.drawText(5, tickny - 5, buf); // draws neg text
             }
 
-            if (!inputSource->realSignal())
-                painter.drawText(5, tickny - 5, buf);
-
-            buf[0] = ' ';
-            painter.drawText(5, tickpy + 15, buf);
+            if (bwPerTick % 1000000000 == 0) {
+              snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000000);
+            } else if (bwPerTick % 1000000 == 0) {
+              snprintf(buf, sizeof(buf), "%d MHz", ((int)frequencyOffset + (int)tick) / 1000000);
+            } else if(bwPerTick % 1000 == 0) {
+              snprintf(buf, sizeof(buf), "%d kHz", ((int)frequencyOffset + (int)tick) / 1000);
+            } else {
+              snprintf(buf, sizeof(buf), "%d Hz", (int)frequencyOffset + tick);
+            }
+             painter.drawText(5, tickpy + 15, buf); // draws pos text
         }
 
         tick += bwPerTick;
     }
 
     // Draw small ticks
-    bwPerTick /= 10;
-
-    if (bwPerTick >= 1 ) {
-        tick = 0;
-        while (tick <= sampleRate / 2) {
-
-            int tickpy = plotHeight / 2 - tick / bwPerPixel + y;
-            int tickny = plotHeight / 2 + tick / bwPerPixel + y;
-
-            if (!inputSource->realSignal())
-                painter.drawLine(0, tickny, 3, tickny);
-            painter.drawLine(0, tickpy, 3, tickpy);
-
-            tick += bwPerTick;
-        }
-    }
+//    bwPerTick /= 10;
+//
+//    if (bwPerTick >= 1 ) {
+//        tick = 0;
+//        while (tick <= sampleRate / 2) {
+//
+//            int tickpy = plotHeight / 2 - tick / bwPerPixel + y;
+//            int tickny = plotHeight / 2 + tick / bwPerPixel + y;
+//
+//            if (!inputSource->realSignal())
+//                painter.drawLine(0, tickny, 3, tickny);
+//            painter.drawLine(0, tickpy, 3, tickpy);
+//
+//            tick += bwPerTick;
+//        }
+//    }
     painter.restore();
 }
 
@@ -327,6 +353,11 @@ void SpectrogramPlot::setZoomLevel(int zoom)
 void SpectrogramPlot::setSampleRate(size_t rate)
 {
     sampleRate = rate;
+}
+
+void SpectrogramPlot::setFrequencyOffset(size_t rate)
+{
+    frequencyOffset = rate;
 }
 
 void SpectrogramPlot::enableScales(bool enabled)

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -46,6 +46,7 @@ public:
     bool mouseEvent(QEvent::Type type, QMouseEvent event) override;
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
     void setSampleRate(size_t sampleRate);
+    void setFrequencyOffset(size_t frequencyOffset);
     bool tunerEnabled();
     void enableScales(bool enabled);
 
@@ -72,6 +73,7 @@ private:
     float powerMax;
     float powerMin;
     size_t sampleRate;
+    size_t frequencyOffset;
     bool frequencyScaleEnabled;
 
     Tuner tuner;


### PR DESCRIPTION
This is a feature to implement a frequency offset, found just below the sample rate. If at 0, Inspectrum will function as it has before, with the center at 0 Hz, with 1/2 sample rate being the positive and negative bounds (eg: -10MHz to 10MHz centered around 0 Hz)

This feature shifts the 0 to the frequency that a user captured. For example, if a user was capturing a 30MHz window centering around 915MHz, they would see:

930MHz (upper bound)
915MHz (center)
900MHz (lower bound)

We also adjust this in accordance to the frequency and the sample rate in accordance how Inspectrum normally runs. We cannot detect this automatically, since IQ captures do not record it. 