### PR TITLE
Maintain the current scroll position when zooming

### DIFF
--- a/plotview.h
+++ b/plotview.h
@@ -71,7 +71,7 @@ private:
     size_t zoomSample;
 
     int fftSize = 1024;
-    int zoomLevel = 0;
+    int zoomLevel = 1;
     int powerMin;
     int powerMax;
     bool cursorsEnabled;
@@ -87,7 +87,7 @@ private:
     int plotsHeight();
     size_t samplesPerColumn();
     void updateViewRange(bool reCenter);
-    void updateView(bool reCenter = false);
+    void updateView(bool reCenter = false, bool expanding = false);
     void paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
 
     int sampleToColumn(size_t sample);


### PR DESCRIPTION
Fixes #157.

When the "Zoom" slider or "FFT size" slider is moved, Inspectrum jumps either to the end of the file or to the last location that was zoomed with Ctrl+scrollwheel. This happens because the code that tracks where the center of the window is was commented out in #131.

The change in #131 also reordered `PlotView::updateView` in an attempt to work around a zoom bug, but it only moved the problem. The underlying issue is that when zooming or changing the FFT size, `horizontalScrollBar()->setMaximum()` and `horizontalScrollBar()->setValue()` must be called in the correct order. When the total width of the FFT data expands, the scroll maximum must be increased before the scroll value, or else the value might be clipped. Conversely, when the total width of the FFT data shrinks, the scroll value must be decreased before the scroll maximum. I've accomplished that here by having `PlotView::setFFTAndZoom()` determine whether the total width is expanding and pass that information into `PlotView::updateViewRange()`, which can then perform the two steps in the correct order.


