### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ dist: bionic
 os:
   - linux
   - osx
-
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - gcc
   - clang
@@ -18,6 +20,8 @@ matrix:
     # /usr/bin/gcc on OS X is clang, so it's not meaningful to build against both.
     - os: osx
       compiler: gcc
+    - os: osx
+      arch: ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/inspectrum/builds/190338051 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!