### PR TITLE
Add plot bandwidth measurement to UI

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -38,7 +38,10 @@ MainWindow::MainWindow()
 
     input = new InputSource();
 
-    plots = new PlotView(input);
+    QSettings settings;
+    tuner = new Tuner(settings.value("FFTSize", 9).toInt(), this);
+
+    plots = new PlotView(input, tuner);
     setCentralWidget(plots);
 
     // Connect dock inputs
@@ -50,6 +53,7 @@ MainWindow::MainWindow()
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);
     connect(dock->scalesCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableScales);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
+    connect(tuner, &Tuner::tunerMoved, dock, &SpectrogramControls::tunerMoved);
 
     // Connect dock outputs
     connect(plots, &PlotView::timeSelectionChanged, dock, &SpectrogramControls::timeSelectionChanged);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -42,4 +42,5 @@ private:
     SpectrogramControls *dock;
     PlotView *plots;
     InputSource *input;
+    Tuner *tuner;
 };

--- a/plotview.cpp
+++ b/plotview.cpp
@@ -34,7 +34,7 @@
 #include <QClipboard>
 #include "plots.h"
 
-PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0})
+PlotView::PlotView(InputSource *input, Tuner *tuner) : cursors(this), viewRange({0, 0})
 {
     mainSampleSource = input;
     setDragMode(QGraphicsView::ScrollHandDrag);
@@ -43,8 +43,10 @@ PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0})
     enableCursors(false);
     connect(&cursors, &Cursors::cursorsMoved, this, &PlotView::cursorsMoved);
 
-    spectrogramPlot = new SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>>(mainSampleSource));
+    spectrogramPlot = new SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>>(mainSampleSource), tuner);
     auto tunerOutput = std::dynamic_pointer_cast<SampleSource<std::complex<float>>>(spectrogramPlot->output());
+
+    connect(tuner, &Tuner::tunerMoved, spectrogramPlot, &SpectrogramPlot::tunerMoved);
 
     enableScales(true);
 

--- a/plotview.h
+++ b/plotview.h
@@ -34,7 +34,7 @@ class PlotView : public QGraphicsView, Subscriber
     Q_OBJECT
 
 public:
-    PlotView(InputSource *input);
+    PlotView(InputSource *input, Tuner *tuner);
     void setSampleRate(double rate);
 
 signals:

--- a/spectrogramcontrols.cpp
+++ b/spectrogramcontrols.cpp
@@ -93,6 +93,9 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     symbolPeriodLabel = new QLabel();
     layout->addRow(new QLabel(tr("Symbol period:")), symbolPeriodLabel);
 
+    bandwidthLabel = new QLabel();
+    layout->addRow(new QLabel(tr("Bandwidth:")), bandwidthLabel);
+
     widget->setLayout(layout);
     setWidget(widget);
 
@@ -110,6 +113,7 @@ void SpectrogramControls::clearCursorLabels()
     rateLabel->setText("");
     symbolPeriodLabel->setText("");
     symbolRateLabel->setText("");
+    bandwidthLabel->setText("");
 }
 
 void SpectrogramControls::cursorsStateChanged(int state)
@@ -225,4 +229,17 @@ void SpectrogramControls::zoomIn()
 void SpectrogramControls::zoomOut()
 {
     zoomLevelSlider->setValue(zoomLevelSlider->value() - 1);
+}
+
+void SpectrogramControls::tunerMoved(int deviation)
+{
+    // int deviation is width in pixels from plot
+    bandwidthLabel->setText(QString::number(getBandwidth(deviation)) + "kHz");
+}
+
+int SpectrogramControls::getBandwidth(int deviation) {
+    double rate = sampleRate->text().toDouble();
+    double fftSize = pow(2, fftSizeSlider->value());
+    double hzPerPx = rate / fftSize;
+    return deviation * hzPerPx / 1000 * 2;
 }

--- a/spectrogramcontrols.h
+++ b/spectrogramcontrols.h
@@ -27,6 +27,7 @@
 #include <QSpinBox>
 #include <QCheckBox>
 #include <QLabel>
+#include "tuner.h"
 
 class SpectrogramControls : public QDockWidget
 {
@@ -44,6 +45,7 @@ public slots:
     void timeSelectionChanged(float time);
     void zoomIn();
     void zoomOut();
+    void tunerMoved(int deviation);
 
 private slots:
     void fftSizeChanged(int value);
@@ -58,6 +60,7 @@ private:
     QFormLayout *layout;
     void clearCursorLabels();
     void fftOrZoomChanged(void);
+    int getBandwidth(int deviation);
 
 public:
     QPushButton *fileOpenButton;
@@ -72,5 +75,7 @@ public:
     QLabel *periodLabel;
     QLabel *symbolRateLabel;
     QLabel *symbolPeriodLabel;
+    QLabel *bandwidthLabel;
     QCheckBox *scalesCheckBox;
+
 };

--- a/spectrogramplot.cpp
+++ b/spectrogramplot.cpp
@@ -31,8 +31,10 @@
 #include "util.h"
 
 
-SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src) : Plot(src), inputSource(src), fftSize(512), tuner(fftSize, this)
+SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src, Tuner *tuner)
+    : Plot(src), inputSource(src), fftSize(512) //, tuner(fftSize, this)
 {
+    this->tuner = tuner;
     setFFTSize(fftSize);
     zoomLevel = 1;
     powerMax = 0.0f;
@@ -46,7 +48,7 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
     }
 
     tunerTransform = std::make_shared<TunerTransform>(src);
-    connect(&tuner, &Tuner::tunerMoved, this, &SpectrogramPlot::tunerMoved);
+//    connect(&tuner, &Tuner::tunerMoved, this, &SpectrogramPlot::tunerMoved);
 }
 
 void SpectrogramPlot::invalidateEvent()
@@ -62,7 +64,7 @@ void SpectrogramPlot::invalidateEvent()
 void SpectrogramPlot::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
 {
     if (tunerEnabled())
-        tuner.paintFront(painter, rect, sampleRange);
+        tuner->paintFront(painter, rect, sampleRange);
 
     if (frequencyScaleEnabled)
         paintFrequencyScale(painter, rect);
@@ -248,13 +250,13 @@ int SpectrogramPlot::getStride()
 
 float SpectrogramPlot::getTunerPhaseInc()
 {
-    auto freq = 0.5f - tuner.centre() / (float)fftSize;
+    auto freq = 0.5f - tuner->centre() / (float)fftSize;
     return freq * Tau;
 }
 
 std::vector<float> SpectrogramPlot::getTunerTaps()
 {
-    float cutoff = tuner.deviation() / (float)fftSize;
+    float cutoff = tuner->deviation() / (float)fftSize;
     float gain = pow(10.0f, powerMax / -10.0f);
     auto atten = 60.0f;
     auto len = estimate_req_filter_len(std::min(cutoff, 0.05f), atten);
@@ -273,7 +275,7 @@ int SpectrogramPlot::linesPerTile()
 bool SpectrogramPlot::mouseEvent(QEvent::Type type, QMouseEvent event)
 {
     if (tunerEnabled())
-        return tuner.mouseEvent(type, event);
+        return tuner->mouseEvent(type, event);
 
     return false;
 }
@@ -299,18 +301,18 @@ void SpectrogramPlot::setFFTSize(int size)
     } else {
         setHeight(fftSize);
     }
-    auto dev = tuner.deviation();
-    auto centre = tuner.centre();
-    tuner.setHeight(height());
-    tuner.setDeviation( dev * sizeScale );
-    tuner.setCentre( centre * sizeScale );
+    auto dev = tuner->deviation();
+    auto centre = tuner->centre();
+    tuner->setHeight(height());
+    tuner->setDeviation( dev * sizeScale );
+    tuner->setCentre( centre * sizeScale );
 }
 
 void SpectrogramPlot::setPowerMax(int power)
 {
     powerMax = power;
     pixmapCache.clear();
-    tunerMoved();
+    tunerMoved(666);
 }
 
 void SpectrogramPlot::setPowerMin(int power)
@@ -339,11 +341,11 @@ bool SpectrogramPlot::tunerEnabled()
     return (tunerTransform->subscriberCount() > 0);
 }
 
-void SpectrogramPlot::tunerMoved()
+void SpectrogramPlot::tunerMoved(int deviation)
 {
     tunerTransform->setFrequency(getTunerPhaseInc());
     tunerTransform->setTaps(getTunerTaps());
-    tunerTransform->setRelativeBandwith(tuner.deviation() * 2.0 / height());
+    tunerTransform->setRelativeBandwith(deviation * 2.0 / height());
 
     // TODO: for invalidating traceplot cache, this shouldn't really go here
     QPixmapCache::clear();

--- a/spectrogramplot.h
+++ b/spectrogramplot.h
@@ -38,7 +38,7 @@ class SpectrogramPlot : public Plot
     Q_OBJECT
 
 public:
-    SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src);
+    SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float>>> src, Tuner *tuner);
     void invalidateEvent() override;
     std::shared_ptr<AbstractSampleSource> output() override;
     void paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleRange) override;
@@ -54,12 +54,13 @@ public slots:
     void setPowerMax(int power);
     void setPowerMin(int power);
     void setZoomLevel(int zoom);
-    void tunerMoved();
+    void tunerMoved(int deviation);
 
 private:
     const int linesPerGraduation = 50;
     static const int tileSize = 65536; // This must be a multiple of the maximum FFT size
 
+    Tuner *tuner;
     std::shared_ptr<SampleSource<std::complex<float>>> inputSource;
     std::unique_ptr<FFT> fft;
     std::unique_ptr<float[]> window;
@@ -74,7 +75,6 @@ private:
     size_t sampleRate;
     bool frequencyScaleEnabled;
 
-    Tuner tuner;
     std::shared_ptr<TunerTransform> tunerTransform;
 
     QPixmap* getPixmapTile(size_t tile);

--- a/tuner.cpp
+++ b/tuner.cpp
@@ -109,6 +109,7 @@ void Tuner::setDeviation(int dev)
 {
     _deviation = std::max(1, dev);
     updateCursors();
+    emit tunerMoved(_deviation);
 }
 
 void Tuner::setHeight(int height)
@@ -120,5 +121,5 @@ void Tuner::updateCursors()
 {
     minCursor->setPos(cfCursor->pos() - _deviation);
     maxCursor->setPos(cfCursor->pos() + _deviation);
-    emit tunerMoved();
+    emit tunerMoved(_deviation);
 }

--- a/tuner.h
+++ b/tuner.h
@@ -44,7 +44,7 @@ public slots:
     void cursorMoved();
 
 signals:
-    void tunerMoved();
+    void tunerMoved(int deviation);
 
 private:
     void updateCursors();


### PR DESCRIPTION
I thought it would be handy to see signal bandwidth in kHz when adjusting plot deviation. See screenshot
I used signals and slots to update the UI, for that I had to move Tuner instantiation to MainWindow. I have very little experience with QT, so I'm not sure if I did it right.

![inspectrum-plot-bw](https://user-images.githubusercontent.com/1789200/96336701-5014be00-108a-11eb-88b1-3a0a2b08d227.png)
