### PR TITLE
Clear SigMF annotations on new file load

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -199,6 +199,7 @@ void InputSource::cleanup()
 #if ENABLE_SIGMF
 void InputSource::readMetaData(const QString &filename)
 {
+    annotationList.clear();
     QFile datafile(filename);
     if (!datafile.open(QFile::ReadOnly | QIODevice::Text)) {
         throw std::runtime_error("Error while opening meta data file: " + datafile.errorString().toStdString());

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -199,7 +199,6 @@ void InputSource::cleanup()
 #if ENABLE_SIGMF
 void InputSource::readMetaData(const QString &filename)
 {
-    annotationList.clear();
     QFile datafile(filename);
     if (!datafile.open(QFile::ReadOnly | QIODevice::Text)) {
         throw std::runtime_error("Error while opening meta data file: " + datafile.errorString().toStdString());
@@ -296,6 +295,7 @@ void InputSource::openFile(const char *filename)
     QString dataFilename;
 
 #if ENABLE_SIGMF
+    annotationList.clear();
     QString metaFilename;
 
     if (suffix == "sigmf-meta") {


### PR DESCRIPTION
When a new file is loaded, the annotations qlist is not cleared, this PR fixes that.