### PR TITLE
add additional sigmf filetype

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -397,13 +397,8 @@ void InputSource::openFile(const char *filename)
     annotationList.clear();
     QString metaFilename;
 
-    if (suffix == "sigmf-meta") {
+    if (suffix == "sigmf-meta" || suffix == "sigmf-data" || suffix == "sigmf-") {
         dataFilename = fileInfo.path() + "/" + fileInfo.completeBaseName() + ".sigmf-data";
-        metaFilename = filename;
-        readMetaData(metaFilename);
-    }
-    else if (suffix == "sigmf-data") {
-        dataFilename = filename;
         metaFilename = fileInfo.path() + "/" + fileInfo.completeBaseName() + ".sigmf-meta";
         readMetaData(metaFilename);
     }


### PR DESCRIPTION
When tab completing sigmf files, the completion will stop at '..sigmf-'
which can be annoying since all information is available to open the
files at this point. Allow opening of the files at this point.