### PR TITLE
adding fft skip (zoom out)

### DIFF
--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -395,9 +395,12 @@ void PlotView::setFFTAndZoom(int size, int zoom)
         spectrogramPlot->setFFTSize(size);
 
     // Set new zoom level
-    zoomLevel = zoom;
-    if (spectrogramPlot != nullptr)
-        spectrogramPlot->setZoomLevel(zoom);
+    zoomLevel = std::max(1,zoom);
+    nfftSkip = std::max(1,-1*zoom);
+    if (spectrogramPlot != nullptr) {
+        spectrogramPlot->setZoomLevel(zoomLevel);
+        spectrogramPlot->setSkip(nfftSkip);
+    }
 
     // Update horizontal (time) scrollbar
     horizontalScrollBar()->setSingleStep(10);
@@ -524,7 +527,7 @@ void PlotView::resizeEvent(QResizeEvent * event)
 
 size_t PlotView::samplesPerColumn()
 {
-    return fftSize / zoomLevel;
+    return fftSize * nfftSkip / zoomLevel;
 }
 
 void PlotView::scrollContentsBy(int dx, int dy)

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -73,6 +73,7 @@ private:
 
     int fftSize = 1024;
     int zoomLevel = 1;
+    int nfftSkip = 1;
     int powerMin;
     int powerMax;
     bool cursorsEnabled;

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -52,7 +52,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("FFT size:")), fftSizeSlider);
 
     zoomLevelSlider = new QSlider(Qt::Horizontal, widget);
-    zoomLevelSlider->setRange(0, 10);
+    zoomLevelSlider->setRange(-6, 10);
     zoomLevelSlider->setPageStep(1);
 
     layout->addRow(new QLabel(tr("Zoom:")), zoomLevelSlider);
@@ -139,7 +139,13 @@ void SpectrogramControls::setDefaults()
 void SpectrogramControls::fftOrZoomChanged(void)
 {
     int fftSize = pow(2, fftSizeSlider->value());
-    int zoomLevel = std::min(fftSize, (int)pow(2, zoomLevelSlider->value()));
+    int zoomLevel = zoomLevelSlider->value();
+    if (zoomLevel >= 0)
+        // zooming in by power-of-two steps
+        zoomLevel = std::min(fftSize, (int)pow(2, zoomLevel));
+    else
+        // zooming out (skipping FFTs) by power-of-two steps
+        zoomLevel = -1*std::min(fftSize, (int)pow(2, -1*zoomLevel));
     emit fftOrZoomChanged(fftSize, zoomLevel);
 }
 

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -35,6 +35,7 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
 {
     setFFTSize(fftSize);
     zoomLevel = 1;
+    nfftSkip = 1;
     powerMax = 0.0f;
     powerMin = -50.0f;
     sampleRate = 0;
@@ -222,7 +223,7 @@ void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> s
 
 QPixmap* SpectrogramPlot::getPixmapTile(size_t tile)
 {
-    QPixmap *obj = pixmapCache.object(TileCacheKey(fftSize, zoomLevel, tile));
+    QPixmap *obj = pixmapCache.object(TileCacheKey(fftSize, zoomLevel, nfftSkip, tile));
     if (obj != 0)
         return obj;
 
@@ -241,13 +242,13 @@ QPixmap* SpectrogramPlot::getPixmapTile(size_t tile)
         }
     }
     obj->convertFromImage(image);
-    pixmapCache.insert(TileCacheKey(fftSize, zoomLevel, tile), obj);
+    pixmapCache.insert(TileCacheKey(fftSize, zoomLevel, nfftSkip, tile), obj);
     return obj;
 }
 
 float* SpectrogramPlot::getFFTTile(size_t tile)
 {
-    std::array<float, tileSize>* obj = fftCache.object(TileCacheKey(fftSize, zoomLevel, tile));
+    std::array<float, tileSize>* obj = fftCache.object(TileCacheKey(fftSize, zoomLevel, nfftSkip, tile));
     if (obj != nullptr)
         return obj->data();
 
@@ -259,7 +260,7 @@ float* SpectrogramPlot::getFFTTile(size_t tile)
         sample += getStride();
         ptr += fftSize;
     }
-    fftCache.insert(TileCacheKey(fftSize, zoomLevel, tile), destStorage);
+    fftCache.insert(TileCacheKey(fftSize, zoomLevel, nfftSkip, tile), destStorage);
     return destStorage->data();
 }
 
@@ -296,7 +297,7 @@ void SpectrogramPlot::getLine(float *dest, size_t sample)
 
 int SpectrogramPlot::getStride()
 {
-    return fftSize / zoomLevel;
+    return fftSize * nfftSkip / zoomLevel;
 }
 
 float SpectrogramPlot::getTunerPhaseInc()
@@ -375,6 +376,11 @@ void SpectrogramPlot::setPowerMin(int power)
 void SpectrogramPlot::setZoomLevel(int zoom)
 {
     zoomLevel = zoom;
+}
+
+void SpectrogramPlot::setSkip(int skip)
+{
+    nfftSkip = skip;
 }
 
 void SpectrogramPlot::setSampleRate(double rate)

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -54,6 +54,7 @@ public slots:
     void setPowerMax(int power);
     void setPowerMin(int power);
     void setZoomLevel(int zoom);
+    void setSkip(int skip);
     void tunerMoved();
 
 private:
@@ -69,6 +70,7 @@ private:
 
     int fftSize;
     int zoomLevel;
+    int nfftSkip;
     float powerMax;
     float powerMin;
     double sampleRate;
@@ -92,19 +94,22 @@ class TileCacheKey
 {
 
 public:
-    TileCacheKey(int fftSize, int zoomLevel, size_t sample) {
+    TileCacheKey(int fftSize, int zoomLevel, int nfftSkip, size_t sample) {
         this->fftSize = fftSize;
         this->zoomLevel = zoomLevel;
+        this->nfftSkip = nfftSkip;
         this->sample = sample;
     }
 
     bool operator==(const TileCacheKey &k2) const {
         return (this->fftSize == k2.fftSize) &&
                (this->zoomLevel == k2.zoomLevel) &&
+               (this->nfftSkip == k2.nfftSkip) &&
                (this->sample == k2.sample);
     }
 
     int fftSize;
     int zoomLevel;
+    int nfftSkip;
     size_t sample;
 };


### PR DESCRIPTION
This is an updated version of #96 I have been using for a bit. There was some discussion back then of the 'right' way to handle zooming out, and some concern that simply striding over the input data was not ideal but I'm submitting this again in case its useful because:

1. You just can't do this right now at all
2. Its super fast still because its not computing an FFT on every data point; one per visible column
3. There is not currently a configuration panel or settings menu to select different decimation behavior
3. I fixed the stuff that did not work correctly in the other PR (time-scale, sigmf annotations)