### PR TITLE
namespace bug, can't build sigmf support without default std namespace

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -29,6 +29,7 @@
 
 #include <QFileInfo>
 
+using namespace std;
 #if ENABLE_SIGMF
 #include <sigmf/sigmf.h>
 #endif


### PR DESCRIPTION
namespace breakage occurred without std namespace - 
somewhere in the depths of json headers it uses begin / end without std:: namespace
this seemed to fix everything
(when building both libsigmf and inspectrum using system nlohmann-json3 and and flatbuffers on Ubuntu 21.04) 
would recommend merging this fix unless the broad namespace upsets someone