### PR TITLE
Keep center frequency when changing FFT size

### DIFF
--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -388,6 +388,7 @@ void PlotView::setCursorSegments(int segments)
     selectedSamples.maximum = selectedSamples.minimum + (segments * sampPerSeg + 0.5f);
 
     cursors.setSegments(segments);
+
     updateView();
     emitTimeSelection();
 }
@@ -395,6 +396,9 @@ void PlotView::setCursorSegments(int segments)
 void PlotView::setFFTAndZoom(int size, int zoom)
 {
     auto oldSamplesPerColumn = samplesPerColumn();
+    float oldPlotCenter = (verticalScrollBar()->value() + viewport()->height() / 2.0) / plotsHeight();
+    if (verticalScrollBar()->maximum() == 0)
+        oldPlotCenter = 0.5;
 
     // Set new FFT size
     fftSize = size;
@@ -411,6 +415,10 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     horizontalScrollBar()->setPageStep(100);
 
     updateView(true, samplesPerColumn() < oldSamplesPerColumn);
+
+    // maintain the relative position of the vertical scroll bar
+    if (verticalScrollBar()->maximum())
+        verticalScrollBar()->setValue((int )(oldPlotCenter * plotsHeight() - viewport()->height() / 2.0 + 0.5f));
 }
 
 void PlotView::setPowerMin(int power)
@@ -567,6 +575,7 @@ void PlotView::updateView(bool reCenter, bool expanding)
     }
     horizontalScrollBar()->setMaximum(std::max(0, sampleToColumn(mainSampleSource->count()) - width()));
     verticalScrollBar()->setMaximum(std::max(0, plotsHeight() - viewport()->height()));
+
     if (expanding) {
         updateViewRange(reCenter);
     }


### PR DESCRIPTION
currently the plot will jump around when changing the FFT size, especially when the FFT size is large. This maintains the relative center bin when zooming.