### PR TITLE
Respond to PageUp/PageDown key presses

### DIFF
--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -181,6 +181,23 @@ void PlotView::enableCursors(bool enabled)
     viewport()->update();
 }
 
+void PlotView::keyPressEvent(QKeyEvent *keyEvent) {
+    int key = keyEvent->key();
+    if (key == Qt::Key_PageDown ||
+        key == Qt::Key_PageUp) {
+
+        int stride = width() - verticalScrollBar()->width();
+
+        horizontalScrollBar()->setValue(
+            horizontalScrollBar()->value() + stride * (key == Qt::Key_PageDown ? 1 : -1)
+        );
+        updateView(false);
+        return;
+    }
+
+    QGraphicsView::keyPressEvent(keyEvent);
+}
+
 bool PlotView::viewportEvent(QEvent *event) {
     // Handle wheel events for zooming (before the parent's handler to stop normal scrolling)
     if (event->type() == QEvent::Wheel) {

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -59,6 +59,7 @@ protected:
     void resizeEvent(QResizeEvent * event) override;
     void scrollContentsBy(int dx, int dy) override;
     bool viewportEvent(QEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
     void showEvent(QShowEvent *event) override;
 
 private:


### PR DESCRIPTION
Shift the view horizontally by one full width. This makes it easier to browse long recordings.