### PR TITLE
Color SigMF Annotations

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -42,6 +42,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QFile>
+#include <QColor>
 
 
 class ComplexF32SampleAdapter : public SampleAdapter {
@@ -244,6 +245,12 @@ void InputSource::readMetaData(const QString &filename)
     for(auto annotation : metaData.annotations) {
         Annotation a;
         auto core = annotation.access<core::AnnotationT>();
+
+        if (QColor::isValidColor(QString::fromStdString(core.comment))) {
+            a.annoColor = QString::fromStdString(core.comment);
+        } else {
+            a.annoColor = QString::fromStdString("white");
+        }
 
         a.sampleRange = range_t<size_t>{core.sample_start, core.sample_start + core.sample_count - 1};
         a.frequencyRange = range_t<double>{core.freq_lower_edge, core.freq_upper_edge};

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,7 @@ MainWindow::MainWindow()
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);
     connect(dock->scalesCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableScales);
     connect(dock->annosCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnos);
+    connect(dock->annoColorCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnoColors);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -51,6 +51,8 @@ PlotView::PlotView(InputSource *input) : cursors(this), viewRange({0, 0})
 
     enableAnnos(true);
 
+    enableAnnoColors(true);
+
     addPlot(spectrogramPlot);
 
     mainSampleSource->subscribe(this);
@@ -608,6 +610,14 @@ void PlotView::enableAnnos(bool enabled)
 {
     if (spectrogramPlot != nullptr)
         spectrogramPlot->enableAnnos(enabled);
+
+    viewport()->update();
+}
+
+void PlotView::enableAnnoColors(bool enabled)
+{
+    if (spectrogramPlot != nullptr)
+        spectrogramPlot->enableAnnoColors(enabled);
 
     viewport()->update();
 }

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -47,6 +47,7 @@ public slots:
     void enableCursors(bool enabled);
     void enableScales(bool enabled);
     void enableAnnos(bool enabled);
+    void enableAnnoColors(bool enabled);
     void invalidateEvent() override;
     void repaint();
     void setCursorSegments(int segments);

--- a/src/samplesource.h
+++ b/src/samplesource.h
@@ -25,6 +25,7 @@
 
 #include "util.h"
 #include <QString>
+#include <QColor>
 #include <QObject>
 
 class Annotation
@@ -32,6 +33,7 @@ class Annotation
 public:
     range_t<size_t> sampleRange;
     range_t<double> frequencyRange;
+    QColor annoColor;
     QString description;
 };
 

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -46,7 +46,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     layout->addRow(new QLabel(tr("<b>Spectrogram</b>")));
 
     fftSizeSlider = new QSlider(Qt::Horizontal, widget);
-    fftSizeSlider->setRange(4, 13);
+    fftSizeSlider->setRange(4, 16);
     fftSizeSlider->setPageStep(1);
 
     layout->addRow(new QLabel(tr("FFT size:")), fftSizeSlider);
@@ -99,6 +99,8 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     annosCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Display Annotations:")), annosCheckBox);
+    annoColorCheckBox = new QCheckBox(widget);
+    layout->addRow(new QLabel(tr("Annotation Colors:")), annoColorCheckBox);
 
     widget->setLayout(layout);
     setWidget(widget);
@@ -134,6 +136,7 @@ void SpectrogramControls::setDefaults()
     cursorSymbolsSpinBox->setValue(1);
 
     annosCheckBox->setCheckState(Qt::Checked);
+    annoColorCheckBox->setCheckState(Qt::Checked);
 
     // Try to set the sample rate from the last-used value
     QSettings settings;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -74,4 +74,5 @@ public:
     QLabel *symbolPeriodLabel;
     QCheckBox *scalesCheckBox;
     QCheckBox *annosCheckBox;
+    QCheckBox *annoColorCheckBox;
 };

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -40,6 +40,7 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
     sampleRate = 0;
     frequencyScaleEnabled = false;
     sigmfAnnotationsEnabled = true;
+    sigmfAnnotationColors = true;
 
     for (int i = 0; i < 256; i++) {
         float p = (float)i / 256;
@@ -191,6 +192,8 @@ void SpectrogramPlot::paintAnnotations(QPainter &painter, QRect &rect, range_t<s
             int y = zero - frequency / sampleRate * rect.height();
             int height = (a.frequencyRange.maximum - a.frequencyRange.minimum) / sampleRate * rect.height();
             int width = (a.sampleRange.maximum - a.sampleRange.minimum) / getStride();
+            
+            if (sigmfAnnotationColors) painter.setPen(a.annoColor);
 
             // Draw the description 2 pixels above the box
             painter.drawText(x, y - 2, a.description);
@@ -393,6 +396,11 @@ void SpectrogramPlot::enableScales(bool enabled)
 void SpectrogramPlot::enableAnnos(bool enabled)
 {
    sigmfAnnotationsEnabled = enabled;
+}
+
+void SpectrogramPlot::enableAnnoColors(bool enabled)
+{
+   sigmfAnnotationColors = enabled;
 }
 
 bool SpectrogramPlot::tunerEnabled()

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -49,6 +49,7 @@ public:
     bool tunerEnabled();
     void enableScales(bool enabled);
     void enableAnnos(bool enabled);
+    void enableAnnoColors(bool enabled);
 
 public slots:
     void setFFTSize(int size);
@@ -75,6 +76,7 @@ private:
     double sampleRate;
     bool frequencyScaleEnabled;
     bool sigmfAnnotationsEnabled;
+    bool sigmfAnnotationColors;
 
     Tuner tuner;
     std::shared_ptr<TunerTransform> tunerTransform;


### PR DESCRIPTION
Adds the ability to color SigMF using the information in the `core:comment` `annotation` SigMF field. If the string in this field is a valid QColor QString (see: https://doc.qt.io/qt-5/qcolor.html#setNamedColor), either a SVG named color or a supported hexadecimal color specification (including alpha) it can be used to set the color of the annotation. This has many uses, and does not require any libsigmf changes. There is also a checkbox to disable custom colors (reverts to white).

![image](https://user-images.githubusercontent.com/7121282/130869463-2afb3653-f829-4dec-bf36-2a86415aa675.png)

```json
{
  ...
  "annotations": [
    {
      "core:sample_start": 3383600,
      "core:sample_count": 197312,
      "core:freq_upper_edge": 201379186,
      "core:freq_lower_edge": 200727361,
      "core:description": "UNKNOWN",
      "core:comment": "#55ffffff"
    },
    {
      "core:sample_start": 7327744,
      "core:sample_count": 397312,
      "core:freq_upper_edge": 198540829,
      "core:freq_lower_edge": 197964200,
      "core:description": "VALID",
      "core:comment": "lightgreen"
    },
    {
      "core:sample_start": 5327744,
      "core:sample_count": 897312,
      "core:freq_upper_edge": 195540829,
      "core:freq_lower_edge": 194964200,
      "core:description": "ERROR",
      "core:comment": "palevioletred"
    },
    ...
  ]
}
```
Closes #189 (as this MR includes it... ill leave that open in case you just want it and not this one).