### PR TITLE
Pretty timescale

### DIFF
--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -492,7 +492,15 @@ void PlotView::paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sa
         int tickLine = sampleToColumn(tickSample - sampleRange.minimum);
 
         char buf[128];
-        snprintf(buf, sizeof(buf), "%.06f s", tick);
+        if (duration < .5)
+            snprintf(buf, sizeof(buf), "%.06f s", tick);
+        else if (duration < 3)
+            snprintf(buf, sizeof(buf), "%.02f s", tick);
+        else if (duration < 10)
+            snprintf(buf, sizeof(buf), "%.02f s", tick);
+        else
+            snprintf(buf, sizeof(buf), "%.0f s", tick);
+
         painter.drawLine(tickLine, 0, tickLine, 30);
         painter.drawText(tickLine + 2, 25, buf);
 


### PR DESCRIPTION
Just a cosmetic change that only shows six decimal places in the time axis when zoomed in a lot. Also added the seconds unit, so it is clear that the horizontal axis is time.