### PR TITLE
sigmf: use core:label instead of core:description in annotations

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -38,6 +38,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QFile>
+#include <QMessageBox>
 
 
 class ComplexF32SampleAdapter : public SampleAdapter {
@@ -319,7 +320,25 @@ void InputSource::readMetaData(const QString &filename)
                 const double freq_upper_edge = sigmf_annotation["core:freq_upper_edge"].toDouble();
                 auto frequencyRange = range_t<double>{freq_lower_edge, freq_upper_edge};
 
-                auto label = sigmf_annotation["core:label"].toString();
+                QString label;
+                if(sigmf_annotation.contains("core:description")) {
+                    static bool warning_shown;
+                    if(!warning_shown) {
+                        QMessageBox msgBox(QMessageBox::Warning, "SigMF Warning", "Support for core:description fields in SigMF annotations is deprectated and will be removed in the future. Please use core:label fields instead.");
+                        msgBox.exec();
+                        warning_shown = true;
+                    }
+
+                    label = sigmf_annotation["core:description"].toString();
+                }
+                else {
+                    if(sigmf_annotation.contains("core:label")) {
+                        label = sigmf_annotation["core:label"].toString();
+                    }
+                    else if(sigmf_annotation.contains("core:comment")) {
+                        label = sigmf_annotation["core:comment"].toString();
+                    }
+                }
 
                 annotationList.emplace_back(sampleRange, frequencyRange, label);
             }


### PR DESCRIPTION
Currently based on #202 

Show a warning when encountering meta data which uses core:description
in annotations.

Show core:comment if core:label is not found.

Closes #199
