### PR TITLE
Fix integer overflow in cursor segment drawing

### DIFF
--- a/src/cursors.cpp
+++ b/src/cursors.cpp
@@ -106,7 +106,7 @@ void Cursors::paintFront(QPainter &painter, QRect &rect, range_t<size_t> sampleR
 
     // Draw vertical edges for individual segments
     painter.setPen(QPen(Qt::gray, 1, Qt::DashLine));
-    for (int i = 1; i < segmentCount; i++) {
+    for (long i = 1; i < segmentCount; i++) {
         int pos = minCursor->pos() + (i * cursorRect.width() / segmentCount);
         painter.drawLine(pos, rect.top(), pos, rect.bottom());
     }


### PR DESCRIPTION
When the number of symbols is large and the cursor selection is wide, the dividing lines between some segments are not drawn:

![Screenshot from 2022-10-05 10-24-55](https://user-images.githubusercontent.com/583749/194086273-fddf086a-5b22-40ff-a70b-f40521e76e9e.png)

This happens because `i * cursorRect.width()` triggers an integer overflow here:

https://github.com/miek/inspectrum/blob/98b998ff3830a129b67148d2b97bdc70c395c12a/src/cursors.cpp#L109-L112

This can be avoided by changing the type of `i` to `long`, which causes the entire calculation to be performed with long integers.