### PR TITLE
Allow up to 99,999 symbols

### DIFF
--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -78,7 +78,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     cursorSymbolsSpinBox = new QSpinBox();
     cursorSymbolsSpinBox->setMinimum(1);
-    cursorSymbolsSpinBox->setMaximum(9999);
+    cursorSymbolsSpinBox->setMaximum(99999);
     layout->addRow(new QLabel(tr("Symbols:")), cursorSymbolsSpinBox);
 
     rateLabel = new QLabel();


### PR DESCRIPTION
At the moment, inspectrum limits the number of symbols to 9,999. When analyzing continuous data streams, I sometimes want to exceed this number. Once #210 is merged, it should be safe to increase the maximum number of symbols, so I'm proposing to do that here.