### PR TITLE
Display annotation comments as tooltips

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -340,7 +340,9 @@ void InputSource::readMetaData(const QString &filename)
 
                 auto label = sigmf_annotation["core:label"].toString();
 
-                annotationList.emplace_back(sampleRange, frequencyRange, label);
+                auto comment = sigmf_annotation["core:comment"].toString();
+
+                annotationList.emplace_back(sampleRange, frequencyRange, label, comment);
             }
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,8 @@ MainWindow::MainWindow()
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);
     connect(dock->scalesCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableScales);
     connect(dock->annosCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnotations);
+    connect(dock->annosCheckBox, &QCheckBox::stateChanged, dock, &SpectrogramControls::enableAnnotations);
+    connect(dock->commentsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnotationCommentsTooltips);
     connect(dock->cursorSymbolsSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), plots, &PlotView::setCursorSegments);
 
     // Connect dock outputs

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -47,6 +47,7 @@ public slots:
     void enableCursors(bool enabled);
     void enableScales(bool enabled);
     void enableAnnotations(bool enabled);
+    void enableAnnotationCommentsTooltips(bool enabled);
     void invalidateEvent() override;
     void repaint();
     void setCursorSegments(int segments);
@@ -55,6 +56,8 @@ public slots:
     void setPowerMax(int power);
 
 protected:
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
     void contextMenuEvent(QContextMenuEvent * event) override;
     void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent * event) override;
@@ -80,6 +83,7 @@ private:
     double sampleRate = 0.0;
     bool timeScaleEnabled;
     int scrollZoomStepsAccumulated = 0;
+    bool annotationCommentsEnabled;
 
     void addPlot(Plot *plot);
     void emitTimeSelection();
@@ -91,6 +95,7 @@ private:
     void updateViewRange(bool reCenter);
     void updateView(bool reCenter = false, bool expanding = false);
     void paintTimeScale(QPainter &painter, QRect &rect, range_t<size_t> sampleRange);
+    void updateAnnotationTooltip(QMouseEvent *event);
 
     int sampleToColumn(size_t sample);
     size_t columnToSample(int col);

--- a/src/samplesource.h
+++ b/src/samplesource.h
@@ -33,9 +33,12 @@ public:
     range_t<size_t> sampleRange;
     range_t<double> frequencyRange;
     QString label;
+    QString comment;
 
-    Annotation(range_t<size_t> sampleRange, range_t<double>frequencyRange, QString label)
-        : sampleRange(sampleRange), frequencyRange(frequencyRange), label(label) {}
+    Annotation(range_t<size_t> sampleRange, range_t<double>frequencyRange, QString label,
+               QString comment)
+      : sampleRange(sampleRange), frequencyRange(frequencyRange), label(label),
+        comment(comment) {}
 };
 
 template<typename T>

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -99,6 +99,8 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     annosCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Display Annotations:")), annosCheckBox);
+    commentsCheckBox = new QCheckBox(widget);
+    layout->addRow(new QLabel(tr("Display annotation comments tooltips:")), commentsCheckBox);
 
     widget->setLayout(layout);
     setWidget(widget);
@@ -134,6 +136,7 @@ void SpectrogramControls::setDefaults()
     cursorSymbolsSpinBox->setValue(1);
 
     annosCheckBox->setCheckState(Qt::Checked);
+    commentsCheckBox->setCheckState(Qt::Checked);
 
     // Try to set the sample rate from the last-used value
     QSettings settings;
@@ -234,4 +237,9 @@ void SpectrogramControls::zoomIn()
 void SpectrogramControls::zoomOut()
 {
     zoomLevelSlider->setValue(zoomLevelSlider->value() - 1);
+}
+
+void SpectrogramControls::enableAnnotations(bool enabled) {
+    // disable annotation comments checkbox when annotations are disabled
+    commentsCheckBox->setEnabled(enabled);
 }

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -44,6 +44,7 @@ public slots:
     void timeSelectionChanged(float time);
     void zoomIn();
     void zoomOut();
+    void enableAnnotations(bool enabled);
 
 private slots:
     void fftSizeChanged(int value);
@@ -74,4 +75,5 @@ public:
     QLabel *symbolPeriodLabel;
     QCheckBox *scalesCheckBox;
     QCheckBox *annosCheckBox;
+    QCheckBox *commentsCheckBox;
 };

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -169,6 +169,8 @@ void SpectrogramPlot::paintAnnotations(QPainter &painter, QRect &rect, range_t<s
     painter.setPen(pen);
     QFontMetrics fm(painter.font());
 
+    visibleAnnotationLocations.clear();
+
     for (int i = 0; i < inputSource->annotationList.size(); i++) {
         Annotation a = inputSource->annotationList.at(i);
 
@@ -195,10 +197,25 @@ void SpectrogramPlot::paintAnnotations(QPainter &painter, QRect &rect, range_t<s
             // Draw the label 2 pixels above the box
             painter.drawText(x, y - 2, a.label);
             painter.drawRect(x, y, width, height);
+
+            visibleAnnotationLocations.emplace_back(a, x, y, width, height);
         }
     }
 
     painter.restore();
+}
+
+QString *SpectrogramPlot::mouseAnnotationComment(const QMouseEvent *event) {
+    auto pos = event->pos();
+    int mouse_x = pos.x();
+    int mouse_y = pos.y();
+
+    for (auto& a : visibleAnnotationLocations) {
+        if (a.isInside(mouse_x, mouse_y)) {
+            return &a.annotation.comment;
+        }
+    }
+    return nullptr;
 }
 
 void SpectrogramPlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleRange)
@@ -393,6 +410,11 @@ void SpectrogramPlot::enableScales(bool enabled)
 void SpectrogramPlot::enableAnnotations(bool enabled)
 {
    sigmfAnnotationsEnabled = enabled;
+}
+
+bool SpectrogramPlot::isAnnotationsEnabled(void)
+{
+    return sigmfAnnotationsEnabled;
 }
 
 bool SpectrogramPlot::tunerEnabled()

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QCache>
+#include <QString>
 #include <QWidget>
 #include "fft.h"
 #include "inputsource.h"
@@ -30,8 +31,10 @@
 #include <memory>
 #include <array>
 #include <math.h>
+#include <vector>
 
 class TileCacheKey;
+class AnnotationLocation;
 
 class SpectrogramPlot : public Plot
 {
@@ -49,6 +52,8 @@ public:
     bool tunerEnabled();
     void enableScales(bool enabled);
     void enableAnnotations(bool enabled);
+    bool isAnnotationsEnabled();
+    QString *mouseAnnotationComment(const QMouseEvent *event);
 
 public slots:
     void setFFTSize(int size);
@@ -62,6 +67,7 @@ private:
     static const int tileSize = 65536; // This must be a multiple of the maximum FFT size
 
     std::shared_ptr<SampleSource<std::complex<float>>> inputSource;
+    std::vector<AnnotationLocation> visibleAnnotationLocations;
     std::unique_ptr<FFT> fft;
     std::unique_ptr<float[]> window;
     QCache<TileCacheKey, QPixmap> pixmapCache;
@@ -109,4 +115,24 @@ public:
     int fftSize;
     int zoomLevel;
     size_t sample;
+};
+
+class AnnotationLocation
+{
+public:
+    Annotation annotation;
+
+    AnnotationLocation(Annotation annotation, int x, int y, int width, int height)
+        : annotation(annotation), x(x), y(y), width(width), height(height) {}
+
+    bool isInside(int pos_x, int pos_y) {
+        return (x <= pos_x) && (pos_x <= x + width)
+            && (y <= pos_y) && (pos_y <= y + height);
+    }
+
+private:
+    int x;
+    int y;
+    int width;
+    int height;
 };


### PR DESCRIPTION
When the mouse is moved over a SigMF annotation rectangle on the waterfall, a tooltip showing the annotation comment is displayed (if the annotation has a comment field).

This feature can be enabled/disabled with a checkbox, in the same way as annotations. If annotations are disabled, the annotation comments checkbox is grayed out and the tooltips are not shown.

---

My main use case for this is to include miscellaneous information (decoded data, metadata, signal properties...) for packets of burst-based communications (for instance LTE) in SigMF annotation comments, so that the user can hover the mouse over the packets on the waterfall and view this information.

The screenshot below shows a proof of concept of this feature. This has been obtained with [this sigmf-meta file](https://github.com/miek/inspectrum/files/9863913/LTE_uplink_847MHz_2022-01-30_30720ksps.sigmf-meta.zip), which goes with [this sigmf-data file](http://eala.destevez.net/~daniel/LTE/LTE_uplink_847MHz_2022-01-30_30720ksps.sigmf-data). The annotations in this file are a mock up written by hand. I'm planning to generate them programmatically for many of the packets.

![inspectrum-annotation-comments](https://user-images.githubusercontent.com/15093841/197877243-0601cb2b-ae80-46ad-ad2b-b4ca1cc3b871.jpg)

Happy to receive feedback about this new feature.