### PR TITLE
fallback to core:description for anno label

### DIFF
--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -339,6 +339,9 @@ void InputSource::readMetaData(const QString &filename)
                 auto frequencyRange = range_t<double>{freq_lower_edge, freq_upper_edge};
 
                 auto label = sigmf_annotation["core:label"].toString();
+                if (label.isEmpty()) {
+                    label = sigmf_annotation["core:description"].toString();
+                }
 
                 annotationList.emplace_back(sampleRange, frequencyRange, label);
             }


### PR DESCRIPTION
As mentioned in https://github.com/miek/inspectrum/pull/205#pullrequestreview-818207350 upstream libsigmf falls back to "description" if "label" is not available. Let's mimic that behaviour. Commit by @jacobagilbert.