### PR TITLE
Handle tooltip comments of overlapping annotations

### DIFF
--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -211,7 +211,7 @@ QString *SpectrogramPlot::mouseAnnotationComment(const QMouseEvent *event) {
     int mouse_y = pos.y();
 
     for (auto& a : visibleAnnotationLocations) {
-        if (a.isInside(mouse_x, mouse_y)) {
+	if (!a.annotation.comment.isEmpty() && a.isInside(mouse_x, mouse_y)) {
             return &a.annotation.comment;
         }
     }


### PR DESCRIPTION
This handles the tooltips displaying the comments of overlapping annotations, as long as only one of the annotations that contain the mouse cursor has a tooltip.

Before, `SpectrogramPlot::getAnnotationComment()` would return the comment of the first annotation that contains the mouse cursor, even if such a comment is an empty `QString`. The empty `QString` would cause that no tooltip is displayed. Now `SpectrogramPlot::getAnnotationComment()` only returns non-empty comments. Therefore, if only one annotation with a comment contains the mouse cursor, the tooltip for that comment will be displayed.

This still does not handle the case when multiple annotations with comments contain the mouse cursor, since it is not clear what is best to do in this case. For now, `SpectrogramPlot::getAnnotationComment()` simply returns one of the applicable comments.