### PR TITLE
sigmf: Add support for datasets

### DIFF
--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -42,7 +42,7 @@ private:
     std::string _fmt;
     bool _realSignal = false;
 
-    void readMetaData(const QString &filename);
+    QJsonObject readMetaData(const QString &filename);
 
 public:
     InputSource();


### PR DESCRIPTION
Sometimes, we want to load a data file found under the `core:dataset` key. In these cases, we need to read the dataset key and overwrite the respective variable.
Further, we'd need to check if the corresponding `sigmf-data` file exists, because it is supposed to take precedence over the dataset file. The dataset file is all called a Non-Conforming-Datafile (NCD).