### PR TITLE
traceplot: Fix divide by zero crash

### DIFF
--- a/src/traceplot.cpp
+++ b/src/traceplot.cpp
@@ -32,7 +32,7 @@ void TracePlot::paintMid(QPainter &painter, QRect &rect, range_t<size_t> sampleR
 {
     if (sampleRange.length() == 0) return;
 
-    int samplesPerColumn = sampleRange.length() / rect.width();
+    int samplesPerColumn = std::max(1UL, sampleRange.length() / rect.width());
     int samplesPerTile = tileWidth * samplesPerColumn;
     size_t tileID = sampleRange.minimum / samplesPerTile;
     size_t tileOffset = sampleRange.minimum % samplesPerTile; // Number of samples to skip from first image tile


### PR DESCRIPTION
Very small files would cause inspectrum to crash with a SIGFPE. In the end, this is caused by input that let's `samplesPerColumn == 0`. Make sure this value is at least `1` and it doesn't crash anymore.

I tested it with all the derived plots. Generate a file as described in #223 and open derived plots. Potentially you need to resize the window to make it crash.

Fixes #223 