### PR TITLE
UI enhancements: preserve cursor state, true freq display, feed symbols to external program, time scrolling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND inspectrum_sources
     samplesource.cpp
     spectrogramcontrols.cpp
     spectrogramplot.cpp
+    symbolprogoutput.cpp
     threshold.cpp
     traceplot.cpp
     tuner.cpp

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -25,6 +25,9 @@ Cursor::Cursor(Qt::Orientation orientation, Qt::CursorShape mouseCursorShape, QO
 
 }
 
+void Cursor::frozen(bool enable) {
+	isFrozen = enable;
+}
 int Cursor::fromPoint(QPoint point)
 {
     return (orientation == Qt::Vertical) ? point.x() : point.y();
@@ -39,17 +42,22 @@ bool Cursor::pointOverCursor(QPoint point)
 
 bool Cursor::mouseEvent(QEvent::Type type, QMouseEvent event)
 {
+	if (isFrozen) {
+		return false;
+	}
     // If the mouse pointer moves over a cursor, display a resize pointer
-    if (pointOverCursor(event.pos()) && type != QEvent::Leave) {
-        if (!cursorOverrided) {
-            cursorOverrided = true;
-            QApplication::setOverrideCursor(QCursor(cursorShape));
-        }
-    // Restore pointer if it moves off the cursor, or leaves the widget
-    } else if (cursorOverrided) {
-        cursorOverrided = false;
-        QApplication::restoreOverrideCursor();
-    }
+	if (pointOverCursor(event.pos()) && type != QEvent::Leave) {
+		if (!cursorOverrided) {
+			cursorOverrided = true;
+			QApplication::setOverrideCursor(QCursor(cursorShape));
+		}
+
+	// Restore pointer if it moves off the cursor, or leaves the widget
+	} else if (cursorOverrided) {
+		cursorOverrided = false;
+		QApplication::restoreOverrideCursor();
+	}
+
 
     // Start dragging on left mouse button press, if over a cursor
     if (type == QEvent::MouseButtonPress) {

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -34,6 +34,8 @@ public:
     void setPos(int newPos);
     bool mouseEvent(QEvent::Type type, QMouseEvent event);
 
+    void frozen(bool enable);
+
 signals:
     void posChanged();
 
@@ -45,5 +47,6 @@ private:
     Qt::CursorShape cursorShape;
     bool dragging = false;
     bool cursorOverrided = false;
+    bool isFrozen = false;
     int cursorPosition = 0;
 };

--- a/src/cursors.cpp
+++ b/src/cursors.cpp
@@ -29,6 +29,11 @@ Cursors::Cursors(QObject * parent) : QObject::QObject(parent)
     connect(maxCursor, &Cursor::posChanged, this, &Cursors::cursorMoved);
 }
 
+void Cursors::frozen(bool enable) {
+	minCursor->frozen(enable);
+	maxCursor->frozen(enable);
+}
+
 void Cursors::cursorMoved()
 {
     // Swap cursors if one has been dragged past the other

--- a/src/cursors.h
+++ b/src/cursors.h
@@ -39,6 +39,9 @@ public:
     void setSegments(int segments);
     void setSelection(range_t<int> selection);
 
+    void frozen(bool enable);
+
+
 public slots:
     void cursorMoved();
 

--- a/src/inputsource.cpp
+++ b/src/inputsource.cpp
@@ -461,6 +461,16 @@ double InputSource::rate()
     return sampleRate;
 }
 
+void InputSource::setCenterFrequency(double freq)
+{
+	centerFreq = freq;
+    invalidate();
+}
+
+double InputSource::centerFrequency()
+{
+    return centerFreq;
+}
 std::unique_ptr<std::complex<float>[]> InputSource::getSamples(size_t start, size_t length)
 {
     if (inputFile == nullptr)

--- a/src/inputsource.h
+++ b/src/inputsource.h
@@ -37,6 +37,7 @@ private:
     QFile *inputFile = nullptr;
     size_t sampleCount = 0;
     double sampleRate = 0.0;
+    double centerFreq = 0.0;
     uchar *mmapData = nullptr;
     std::unique_ptr<SampleAdapter> sampleAdapter;
     std::string _fmt;
@@ -54,8 +55,10 @@ public:
         return sampleCount;
     };
     void setSampleRate(double rate);
+    void setCenterFrequency(double freq);
     void setFormat(std::string fmt);
     double rate();
+    double centerFrequency();
     bool realSignal() {
         return _realSignal;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,11 @@ int main(int argc, char *argv[])
                                   QCoreApplication::translate("main", "fmt"));
     parser.addOption(formatOption);
 
+    QCommandLineOption centerFreqOption(QStringList() << "c" << "centerfreq",
+                                  QCoreApplication::translate("main", "Set center frequency."),
+                                  QCoreApplication::translate("main", "Hz"));
+    parser.addOption(centerFreqOption);
+
     // Process the actual command line
     parser.process(a);
  
@@ -57,14 +62,24 @@ int main(int argc, char *argv[])
     if (args.size()>=1)
         mainWin.openFile(args.at(0));
 
+    bool ok;
     if (parser.isSet(rateOption)) {
-        bool ok;
         auto rate = parser.value(rateOption).toDouble(&ok);
         if(!ok) {
             fputs("ERROR: could not parse rate\n", stderr);
             return 1;
         }
         mainWin.setSampleRate(rate);
+    }
+
+
+    if (parser.isSet(centerFreqOption)) {
+        auto centerfreq = parser.value(centerFreqOption).toDouble(&ok);
+        if(!ok) {
+            fputs("ERROR: could not parse center frequency\n", stderr);
+            return 1;
+        }
+        mainWin.setCenterFrequency(centerfreq);
     }
 
     mainWin.show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,7 +44,9 @@ MainWindow::MainWindow()
 
     // Connect dock inputs
     connect(dock, &SpectrogramControls::openFile, this, &MainWindow::openFile);
+
     connect(dock->sampleRate, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textChanged), this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::setSampleRate));
+    connect(dock->centerFrequency, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textChanged), this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::setCenterFrequency));
     connect(dock, static_cast<void (SpectrogramControls::*)(int, int)>(&SpectrogramControls::fftOrZoomChanged), plots, &PlotView::setFFTAndZoom);
     connect(dock->powerMaxSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMax);
     connect(dock->powerMinSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMin);
@@ -88,6 +90,14 @@ void MainWindow::openFile(QString fileName)
         if (!ss.fail()) {
             setSampleRate(rate);
         }
+
+
+        std::stringstream ssfreq(centerfreq.toUtf8().constData());
+        double freq;
+        ssfreq >> freq;
+        if (!ssfreq.fail()) {
+        	setCenterFrequency(freq);
+        }
     }
 
     try
@@ -104,6 +114,7 @@ void MainWindow::openFile(QString fileName)
 void MainWindow::invalidateEvent()
 {
     plots->setSampleRate(input->rate());
+    plots->setCenterFrequency(input->centerFrequency());
 
     // Only update the text box if it is not already representing
     // the current value. Otherwise the cursor might jump or the
@@ -128,6 +139,22 @@ void MainWindow::setSampleRate(QString rate)
 void MainWindow::setSampleRate(double rate)
 {
     dock->sampleRate->setText(QString::number(rate));
+}
+
+void MainWindow::setCenterFrequency(QString freq)
+{
+    auto centerFreq = freq.toDouble();
+    input->setCenterFrequency(centerFreq);
+    plots->setCenterFrequency(centerFreq);
+
+    // Save the sample rate in settings as we're likely to be opening the same file across multiple runs
+    QSettings settings;
+    settings.setValue("CenterFrequency", centerFreq);
+}
+
+void MainWindow::setCenterFrequency(double freq)
+{
+    dock->centerFrequency->setText(QString::number(freq));
 }
 
 void MainWindow::setFormat(QString fmt)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,6 +49,7 @@ MainWindow::MainWindow()
     connect(dock->powerMaxSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMax);
     connect(dock->powerMinSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMin);
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);
+    connect(dock->cursorsFreezeCheckBox, &QCheckBox::stateChanged, plots, &PlotView::freezeCursors);
     connect(dock->scalesCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableScales);
     connect(dock->annosCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableAnnotations);
     connect(dock->annosCheckBox, &QCheckBox::stateChanged, dock, &SpectrogramControls::enableAnnotations);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -36,6 +36,8 @@ public slots:
     void openFile(QString fileName);
     void setSampleRate(QString rate);
     void setSampleRate(double rate);
+    void setCenterFrequency(QString centerfreq);
+    void setCenterFrequency(double centerfreq);
     void setFormat(QString fmt);
     void invalidateEvent() override;
 

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -199,6 +199,8 @@ void PlotView::cursorsMoved()
         columnToSample(horizontalScrollBar()->value() + cursors.selection().maximum)
     };
 
+    samplesPerSegment = selectedSamples.length() / cursors.segments();
+
     emitTimeSelection();
     viewport()->update();
 }
@@ -451,14 +453,17 @@ void PlotView::repaint()
     viewport()->update();
 }
 
+#include <iostream>
 void PlotView::setCursorSegments(int segments)
 {
-    // Calculate number of samples per segment
-    float sampPerSeg = (float)selectedSamples.length() / cursors.segments();
 
-    // Alter selection to keep samples per segment the same
-    selectedSamples.maximum = selectedSamples.minimum + (segments * sampPerSeg + 0.5f);
+    int curSegments = cursors.segments();
+    if (curSegments != segments) {
 
+    	int deltaSegments = segments - curSegments;
+        // Calculate number of samples per segment
+        selectedSamples.maximum = selectedSamples.maximum + (deltaSegments * samplesPerSegment);
+    }
     cursors.setSegments(segments);
     updateView();
     emitTimeSelection();
@@ -671,8 +676,7 @@ void PlotView::setCenterFrequency(double freq) {
 
     if (spectrogramPlot != nullptr)
         spectrogramPlot->setCenterFrequency(freq);
-#warning "PSY EMIT WHAT?"
-    emitTimeSelection();
+
 }
 
 void PlotView::enableScales(bool enabled)

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -664,6 +664,17 @@ void PlotView::setSampleRate(double rate)
     emitTimeSelection();
 }
 
+
+void PlotView::setCenterFrequency(double freq) {
+
+    centerFrequency = freq;
+
+    if (spectrogramPlot != nullptr)
+        spectrogramPlot->setCenterFrequency(freq);
+#warning "PSY EMIT WHAT?"
+    emitTimeSelection();
+}
+
 void PlotView::enableScales(bool enabled)
 {
     timeScaleEnabled = enabled;

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -283,10 +283,17 @@ bool PlotView::viewportEvent(QEvent *event) {
     // Handle wheel events for zooming (before the parent's handler to stop normal scrolling)
     if (event->type() == QEvent::Wheel) {
         QWheelEvent *wheelEvent = (QWheelEvent*)event;
-        if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+        int delta = wheelEvent->angleDelta().y();
+
+        if (QApplication::keyboardModifiers() & Qt::ShiftModifier) {
+    		QScrollBar *scrollBar = horizontalScrollBar();
+        	scrollBar->setValue(scrollBar->value() + scrollBar->pageStep() * -1 * delta);
+
+        	return true;
+
+        } else if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
             bool canZoomIn = zoomLevel < fftSize;
             bool canZoomOut = zoomLevel > 1;
-            int delta = wheelEvent->angleDelta().y();
             if ((delta > 0 && canZoomIn) || (delta < 0 && canZoomOut)) {
                 scrollZoomStepsAccumulated += delta;
 
@@ -307,6 +314,9 @@ bool PlotView::viewportEvent(QEvent *event) {
                 }
             }
             return true;
+        } else {
+        	QScrollBar *scrollBar = horizontalScrollBar();
+        	scrollBar->setValue(scrollBar->value() - delta);
         }
     }
 

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -98,6 +98,7 @@ private:
     void addPlot(Plot *plot);
     void emitTimeSelection();
     void extractSymbols(std::shared_ptr<AbstractSampleSource> src, bool toClipboard);
+    void feedSymbolsToExternalProgram(std::shared_ptr<AbstractSampleSource> src);
     void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     template<typename SOURCETYPE> void exportSamples(std::shared_ptr<AbstractSampleSource> src);
     int plotsHeight();
@@ -110,3 +111,5 @@ private:
     int sampleToColumn(size_t sample);
     size_t columnToSample(int col);
 };
+
+

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -29,6 +29,10 @@
 #include "spectrogramplot.h"
 #include "traceplot.h"
 
+typedef struct PlotViewFrozenCursors {
+	bool enabled;
+	range_t<int> range;
+} FrozenCursors;
 class PlotView : public QGraphicsView, Subscriber
 {
     Q_OBJECT
@@ -45,6 +49,7 @@ signals:
 public slots:
     void cursorsMoved();
     void enableCursors(bool enabled);
+    void freezeCursors(bool enabled);
     void enableScales(bool enabled);
     void enableAnnotations(bool enabled);
     void enableAnnotationCommentsTooltips(bool enabled);
@@ -80,6 +85,7 @@ private:
     int powerMin;
     int powerMax;
     bool cursorsEnabled;
+    FrozenCursors cursorsFrozen;
     double sampleRate = 0.0;
     bool timeScaleEnabled;
     int scrollZoomStepsAccumulated = 0;

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -78,6 +78,8 @@ private:
     std::vector<std::unique_ptr<Plot>> plots;
     range_t<size_t> viewRange;
     range_t<size_t> selectedSamples;
+    size_t samplesPerSegment;
+
     int zoomPos;
     size_t zoomSample;
 

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -40,6 +40,7 @@ class PlotView : public QGraphicsView, Subscriber
 public:
     PlotView(InputSource *input);
     void setSampleRate(double rate);
+    void setCenterFrequency(double freq);
 
 signals:
     void timeSelectionChanged(float time);
@@ -87,6 +88,7 @@ private:
     bool cursorsEnabled;
     FrozenCursors cursorsFrozen;
     double sampleRate = 0.0;
+    double centerFrequency = 0.0;
     bool timeScaleEnabled;
     int scrollZoomStepsAccumulated = 0;
     bool annotationCommentsEnabled;

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -75,6 +75,8 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     cursorsCheckBox = new QCheckBox(widget);
     layout->addRow(new QLabel(tr("Enable cursors:")), cursorsCheckBox);
+    cursorsFreezeCheckBox = new QCheckBox(widget);
+    layout->addRow(new QLabel(tr("Freeze cursors:")), cursorsFreezeCheckBox);
 
     cursorSymbolsSpinBox = new QSpinBox();
     cursorSymbolsSpinBox->setMinimum(1);

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -157,6 +157,9 @@ void SpectrogramControls::setDefaults()
     powerMaxSlider->setValue(settings.value("PowerMax", 0).toInt());
     powerMinSlider->setValue(settings.value("PowerMin", -100).toInt());
     zoomLevelSlider->setValue(settings.value("ZoomLevel", 0).toInt());
+
+    int savedFreq = settings.value("CenterFrequency", 0).toInt();
+    centerFrequency->setText(QString::number(savedFreq));
 }
 
 void SpectrogramControls::fftOrZoomChanged(void)

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -41,6 +41,15 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
     sampleRate->setValidator(double_validator);
     layout->addRow(new QLabel(tr("Sample rate:")), sampleRate);
 
+
+
+
+    centerFrequency = new QLineEdit();
+    auto freq_double_validator = new QDoubleValidator(this);
+    freq_double_validator->setBottom(0.0);
+    centerFrequency->setValidator(freq_double_validator);
+    layout->addRow(new QLabel(tr("Center frequency:")), centerFrequency);
+
     // Spectrogram settings
     layout->addRow(new QLabel()); // TODO: find a better way to add an empty row?
     layout->addRow(new QLabel(tr("<b>Spectrogram</b>")));

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -69,6 +69,7 @@ public:
     QSlider *powerMinSlider;
     QCheckBox *cursorsCheckBox;
     QSpinBox *cursorSymbolsSpinBox;
+    QCheckBox *cursorsFreezeCheckBox;
     QLabel *rateLabel;
     QLabel *periodLabel;
     QLabel *symbolRateLabel;

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -63,6 +63,7 @@ private:
 public:
     QPushButton *fileOpenButton;
     QLineEdit *sampleRate;
+    QLineEdit *centerFrequency;
     QSlider *fftSizeSlider;
     QSlider *zoomLevelSlider;
     QSlider *powerMaxSlider;

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -49,6 +49,7 @@ public:
     bool mouseEvent(QEvent::Type type, QMouseEvent event) override;
     std::shared_ptr<SampleSource<std::complex<float>>> input() { return inputSource; };
     void setSampleRate(double sampleRate);
+    void setCenterFrequency(double freq);
     bool tunerEnabled();
     void enableScales(bool enabled);
     void enableAnnotations(bool enabled);
@@ -79,6 +80,7 @@ private:
     float powerMax;
     float powerMin;
     double sampleRate;
+    double centerFrequency;
     bool frequencyScaleEnabled;
     bool sigmfAnnotationsEnabled;
 

--- a/src/symbolprogoutput.cpp
+++ b/src/symbolprogoutput.cpp
@@ -1,0 +1,47 @@
+/*
+ * symbolprogoutput.cpp, part of the Inspectrum project
+ *
+ *  Created on: Aug 27, 2025
+ *      Author: Pat Deegan
+ *  Copyright (C) 2025 Pat Deegan, https://psychogenic.com
+ */
+
+#include "symbolprogoutput.h"
+SymbolProgOutput::SymbolProgOutput(const QString &output, QWidget *parent, size_t width, size_t height) :
+		QDialog(parent)
+{
+	setWindowTitle("Program Output");
+	setMinimumSize(width, height);
+
+	// Create layout
+	QVBoxLayout *layout = new QVBoxLayout(this);
+
+	// Create text edit for output (scrollable)
+	textEdit = new QTextEdit(this);
+	textEdit->setReadOnly(true); // Prevent editing
+	textEdit->setText(output);   // Set the output text
+	layout->addWidget(textEdit);
+
+	// Create buttons
+	QHBoxLayout *buttonLayout = new QHBoxLayout();
+	QPushButton *copyButton = new QPushButton("Copy to Clipboard", this);
+	QPushButton *closeButton = new QPushButton("Close", this);
+	buttonLayout->addWidget(copyButton);
+	buttonLayout->addWidget(closeButton);
+	layout->addLayout(buttonLayout);
+
+	// Connect buttons
+	connect(copyButton, &QPushButton::clicked, this,
+			&SymbolProgOutput::copyToClipboard);
+	connect(closeButton, &QPushButton::clicked, this, &QDialog::accept);
+
+	// Make dialog resizable
+	setSizeGripEnabled(true);
+}
+
+void SymbolProgOutput::copyToClipboard() {
+	textEdit->selectAll();
+	textEdit->copy();
+	textEdit->textCursor().clearSelection(); // Deselect after copying
+}
+

--- a/src/symbolprogoutput.h
+++ b/src/symbolprogoutput.h
@@ -1,0 +1,27 @@
+/*
+ * symbolprogoutput.h, part of the Inspectrum project
+ *
+ *  Created on: Aug 27, 2025
+ *      Author: Pat Deegan
+ *  Copyright (C) 2025 Pat Deegan, https://psychogenic.com
+ */
+
+#pragma once
+#include <QDialog>
+#include <QTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+class SymbolProgOutput : public QDialog
+{
+    Q_OBJECT
+public:
+    SymbolProgOutput(const QString& output, QWidget* parent = nullptr, size_t width = 700, size_t height = 500);
+
+private slots:
+    void copyToClipboard();
+
+private:
+    QTextEdit* textEdit;
+};
+


### PR DESCRIPTION
A number of enhancements that make the experience more wonderful.

  1) Preserving cursor state

The time cursors were always returning to their 1/3 of window state.  Now they remember their last size.

  2) Optionally specifying the center frequency (command line or GUI) lets you see true frequencies on axis

  3)  Tweak to the add/remove symbol segments so it will stop playing with the size of a symbol unit so much
  
  4) Outputting symbols directly to an external program (piped into stdin) so you can stop with the cut & paste and see results from your parser straight in inspectrum.  This is a new option in the right-click context menu, and will just report whatever the program has output

<img width="2705" height="1335" alt="symbolstoexternal" src="https://github.com/user-attachments/assets/36c1eb1d-f1c5-4d68-8fc9-b6ecdab365f9" />

  5) Scroll now... scrolls!  Scrolling without CTRL modifier will scroll timeline.  SHIFT+scroll advances in pages.
  
  
  
   